### PR TITLE
Fixed PR-AZR-ARM-AGW-002: Azure Application Gateway should have the Web application firewall (WAF) enabled

### DIFF
--- a/APP_GW/appgw.azuredeploy.json
+++ b/APP_GW/appgw.azuredeploy.json
@@ -38,41 +38,41 @@
         },
         "wafEnabled": {
             "type": "bool",
-            "defaultValue": false,
+            "defaultValue": true,
             "metadata": {
-            "description": "WAF Enabled"
+                "description": "WAF Enabled"
             }
         },
         "wafMode": {
             "type": "string",
             "allowedValues": [
-            "Detection",
-            "Prevention"
+                "Detection",
+                "Prevention"
             ],
             "defaultValue": "Detection",
             "metadata": {
-            "description": "WAF Mode"
+                "description": "WAF Mode"
             }
         },
         "wafRuleSetType": {
             "type": "string",
             "allowedValues": [
-            "OWASP"
+                "OWASP"
             ],
             "defaultValue": "OWASP",
             "metadata": {
-            "description": "WAF Rule Set Type"
+                "description": "WAF Rule Set Type"
             }
         },
         "wafRuleSetVersion": {
             "type": "string",
             "allowedValues": [
-            "2.2.9",
-            "3.0"
+                "2.2.9",
+                "3.0"
             ],
             "defaultValue": "3.0",
             "metadata": {
-            "description": "WAF Rule Set Version"
+                "description": "WAF Rule Set Version"
             }
         }
     },


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AGW-002 

 **Violation Description:** 

 Azure Web Application Firewall (WAF) on Azure Application Gateway provides centralized protection of your web applications from common exploits and vulnerabilities. Web applications are increasingly targeted by malicious attacks that exploit commonly known vulnerabilities. SQL injection and cross-site scripting are among the most common attacks. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for Application Gateway by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways' target='_blank'>here</a>. webApplicationFirewallConfiguration should be enabled