### PR TITLE
Fixed PR-AZR-ARM-ACR-002: Ensure that admin user is disabled for Container Registry

### DIFF
--- a/ACR/acr.azuredeploy.parameters.json
+++ b/ACR/acr.azuredeploy.parameters.json
@@ -6,7 +6,7 @@
       "value": "asadsadasdas"
     },
     "acrAdminUserEnabled": {
-      "value": true
+      "value": false
     },
     "location": {
       "value": "eastus"


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-ACR-002 

 **Violation Description:** 

 The value that indicates whether the admin user is enabled. Each container registry includes an admin user account, which is disabled by default. You can enable the admin user and manage its credentials in the Azure portal, or by using the Azure CLI or other Azure tools. All users authenticating with the admin account appear as a single user with push and pull access to the registry. Changing or disabling this account disables registry access for all users who use its credentials. 

 **How to Fix:** 

 In Resource of type "Microsoft.containerregistry/registries" make sure properties.adminUserEnabled is set to "Disabled" .<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerregistry/registries' target='_blank'>here</a> for more details.