### PR TITLE
Fixed PR-AZR-ARM-ACR-003: Azure Container Registry should not use the deprecated classic registry

### DIFF
--- a/ACR/acr.azuredeploy.parameters.json
+++ b/ACR/acr.azuredeploy.parameters.json
@@ -12,7 +12,7 @@
       "value": "eastus"
     },
     "acrSku": {
-      "value": "Classic"
+      "value": "Standard"
     },
     "status": {
       "value": "enabled"


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-ACR-003 

 **Violation Description:** 

 This policy identifies an Azure Container Registry (ACR) that is using the classic SKU. The initial release of the Azure Container Registry (ACR) service that was offered as a classic SKU is being deprecated and will be unavailable after April 2019. As a best practice, upgrade your existing classic registry to a managed registry.<br><br>For more information, visit https://docs.microsoft.com/en-us/azure/container-registry/container-registry-upgrade 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for container registry by visiting <a href='https://docs.microsoft.com/en-us/rest/api/containerregistry/registries/list' target='_blank'>here</a>