### PR TITLE
Fixed PR-AZR-ARM-SQL-020: Azure SQL Server threat detection alerts should be enabled for all threat types

### DIFF
--- a/SQL/SQL-DB/sqldb.azuredeploy.json
+++ b/SQL/SQL-DB/sqldb.azuredeploy.json
@@ -86,22 +86,23 @@
                 "minCapacity": "[parameters('minCapacity')]",
                 "autoPauseDelay": "[parameters('autoPauseDelay')]"
             },
-            "resources":[
+            "resources": [
                 {
-                        "condition": "[parameters('enableVA')]",
-                        "type": "vulnerabilityAssessments",
-                        "apiVersion": "2018-06-01-preview",
-                        "name": "Default",
-                        "properties": {
-                            "storageContainerPath": "",
-                            "storageAccountAccessKey": "",
-                            "recurringScans": {
-                                "isEnabled": false,
-                                "emailSubscriptionAdmins": false
-                            }
-                        }
-                  },
-                  {
+                    "condition": "[parameters('enableVA')]",
+                    "type": "securityAlertPolicies",
+                    "apiVersion": "2020-02-02-preview",
+                    "name": "Default",
+                    "properties": {
+                        "storageContainerPath": "",
+                        "storageAccountAccessKey": "",
+                        "recurringScans": {
+                            "isEnabled": false,
+                            "emailSubscriptionAdmins": false
+                        },
+                        "disabledAlerts": []
+                    }
+                },
+                {
                     "type": "auditingSettings",
                     "apiVersion": "2020-08-01-preview",
                     "name": "Default",
@@ -114,22 +115,24 @@
                         "storageAccountSubscriptionId": "",
                         "isStorageSecondaryKeyInUse": false
                     }
-                 },
-                 {
+                },
+                {
                     "type": "transparentDataEncryption",
                     "apiVersion": "2014-04-01",
                     "name": "current",
                     "properties": {
-                      "status": "[parameters('transparentDataEncryptionStatus')]"
+                        "status": "[parameters('transparentDataEncryptionStatus')]"
                     }
-                 },
-                 {
+                },
+                {
                     "type": "securityAlertPolicies",
                     "apiVersion": "2020-02-02-preview",
                     "name": "Default",
                     "properties": {
                         "state": "Disabled",
-                        "disabledAlerts": ["Access_Anomaly"]
+                        "disabledAlerts": [
+                            "Access_Anomaly"
+                        ]
                     }
                 }
             ],
@@ -143,7 +146,7 @@
             "apiVersion": "2014-04-01",
             "name": "current",
             "properties": {
-              "status": "[parameters('transparentDataEncryptionStatus')]"
+                "status": "[parameters('transparentDataEncryptionStatus')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-020 

 **Violation Description:** 

 Advanced data security (ADS) provides a set of advanced SQL security capabilities, including vulnerability assessment, threat detection, and data discovery and classification._x005F<br>_x005F<br>This policy identifies Azure SQL servers that have disabled the detection of one or more threat types. To protect your SQL Servers, as a best practice, enable ADS detection for all types of threats. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL Server by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2018-06-01-preview/servers/databases/securityalertpolicies' target='_blank'>here</a>. disabledAlerts should be empty or not present