### PR TITLE
Fixed PR-AZR-ARM-SQL-017: SQL Databases should have security alert policies enabled

### DIFF
--- a/SQL/SQL-DB/sqldb.azuredeploy.json
+++ b/SQL/SQL-DB/sqldb.azuredeploy.json
@@ -86,22 +86,22 @@
                 "minCapacity": "[parameters('minCapacity')]",
                 "autoPauseDelay": "[parameters('autoPauseDelay')]"
             },
-            "resources":[
+            "resources": [
                 {
-                        "condition": "[parameters('enableVA')]",
-                        "type": "vulnerabilityAssessments",
-                        "apiVersion": "2018-06-01-preview",
-                        "name": "Default",
-                        "properties": {
-                            "storageContainerPath": "",
-                            "storageAccountAccessKey": "",
-                            "recurringScans": {
-                                "isEnabled": false,
-                                "emailSubscriptionAdmins": false
-                            }
+                    "condition": "[parameters('enableVA')]",
+                    "type": "vulnerabilityAssessments",
+                    "apiVersion": "2018-06-01-preview",
+                    "name": "Default",
+                    "properties": {
+                        "storageContainerPath": "",
+                        "storageAccountAccessKey": "",
+                        "recurringScans": {
+                            "isEnabled": false,
+                            "emailSubscriptionAdmins": false
                         }
-                  },
-                  {
+                    }
+                },
+                {
                     "type": "auditingSettings",
                     "apiVersion": "2020-08-01-preview",
                     "name": "Default",
@@ -114,22 +114,24 @@
                         "storageAccountSubscriptionId": "",
                         "isStorageSecondaryKeyInUse": false
                     }
-                 },
-                 {
+                },
+                {
                     "type": "transparentDataEncryption",
                     "apiVersion": "2014-04-01",
                     "name": "current",
                     "properties": {
-                      "status": "[parameters('transparentDataEncryptionStatus')]"
+                        "status": "[parameters('transparentDataEncryptionStatus')]"
                     }
-                 },
-                 {
+                },
+                {
                     "type": "securityAlertPolicies",
                     "apiVersion": "2020-02-02-preview",
                     "name": "Default",
                     "properties": {
-                        "state": "Disabled",
-                        "disabledAlerts": ["Access_Anomaly"]
+                        "state": "Enabled",
+                        "disabledAlerts": [
+                            "Access_Anomaly"
+                        ]
                     }
                 }
             ],
@@ -143,7 +145,7 @@
             "apiVersion": "2014-04-01",
             "name": "current",
             "properties": {
-              "status": "[parameters('transparentDataEncryptionStatus')]"
+                "status": "[parameters('transparentDataEncryptionStatus')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-017 

 **Violation Description:** 

 SQL Threat Detection provides a new layer of security, which enables customers to detect and respond to potential threats as they occur by providing security alerts on anomalous activities. Users will receive an alert upon suspicious database activities, potential vulnerabilities, and SQL injection attacks, as well as anomalous database access patterns. SQL Threat Detection alerts provide details of suspicious activity and recommend action on how to investigate and mitigate the threat. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL Server by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2018-06-01-preview/servers/databases/securityalertpolicies' target='_blank'>here</a>. state should be enabled