### PR TITLE
Fixed PR-AZR-ARM-SQL-007: Azure SQL Database Auditing Retention should be 90 days or more

### DIFF
--- a/SQL/SQL-DB/sqldb.azuredeploy.json
+++ b/SQL/SQL-DB/sqldb.azuredeploy.json
@@ -86,22 +86,28 @@
                 "minCapacity": "[parameters('minCapacity')]",
                 "autoPauseDelay": "[parameters('autoPauseDelay')]"
             },
-            "resources":[
+            "resources": [
                 {
-                        "condition": "[parameters('enableVA')]",
-                        "type": "vulnerabilityAssessments",
-                        "apiVersion": "2018-06-01-preview",
-                        "name": "Default",
-                        "properties": {
-                            "storageContainerPath": "",
-                            "storageAccountAccessKey": "",
-                            "recurringScans": {
-                                "isEnabled": false,
-                                "emailSubscriptionAdmins": false
-                            }
-                        }
-                  },
-                  {
+                    "condition": "[parameters('enableVA')]",
+                    "type": "auditingSettings",
+                    "apiVersion": "2020-08-01-preview",
+                    "name": "Default",
+                    "properties": {
+                        "storageContainerPath": "",
+                        "storageAccountAccessKey": "",
+                        "recurringScans": {
+                            "isEnabled": false,
+                            "emailSubscriptionAdmins": false
+                        },
+                        "state": "Disabled",
+                        "storageEndpoint": "",
+                        "retentionDays": 90,
+                        "auditActionsAndGroups": null,
+                        "storageAccountSubscriptionId": "",
+                        "isStorageSecondaryKeyInUse": false
+                    }
+                },
+                {
                     "type": "auditingSettings",
                     "apiVersion": "2020-08-01-preview",
                     "name": "Default",
@@ -114,22 +120,24 @@
                         "storageAccountSubscriptionId": "",
                         "isStorageSecondaryKeyInUse": false
                     }
-                 },
-                 {
+                },
+                {
                     "type": "transparentDataEncryption",
                     "apiVersion": "2014-04-01",
                     "name": "current",
                     "properties": {
-                      "status": "[parameters('transparentDataEncryptionStatus')]"
+                        "status": "[parameters('transparentDataEncryptionStatus')]"
                     }
-                 },
-                 {
+                },
+                {
                     "type": "securityAlertPolicies",
                     "apiVersion": "2020-02-02-preview",
                     "name": "Default",
                     "properties": {
                         "state": "Disabled",
-                        "disabledAlerts": ["Access_Anomaly"]
+                        "disabledAlerts": [
+                            "Access_Anomaly"
+                        ]
                     }
                 }
             ],
@@ -143,7 +151,7 @@
             "apiVersion": "2014-04-01",
             "name": "current",
             "properties": {
-              "status": "[parameters('transparentDataEncryptionStatus')]"
+                "status": "[parameters('transparentDataEncryptionStatus')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-007 

 **Violation Description:** 

 This policy identifies SQL Databases which have Auditing Retention less than 90 days. Audit Logs can be used to check for anomalies and gives insight into suspected breaches or misuse of information and access. It is recommended to configure SQL database Audit Retention to be greater than or equal to 90 days. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL Server by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2017-03-01-preview/servers/databases/auditingsettings' target='_blank'>here</a>. Make sure retentionDays is at least 90