### PR TITLE
Fixed PR-AZR-ARM-MNT-005: Azure storage account blob services diagnostic logs should be enabled

### DIFF
--- a/storage/StorageA/blob.azuredeploy.json
+++ b/storage/StorageA/blob.azuredeploy.json
@@ -35,7 +35,7 @@
         "containerName": {
             "type": "string"
         },
-        "workspaceName" : {
+        "workspaceName": {
             "type": "string",
             "defaultValue": "GEN-UNIQUE"
         },
@@ -75,7 +75,7 @@
                     "keySource": "Microsoft.Storage"
                 }
             },
-            "resources":[
+            "resources": [
                 {
                     "type": "blobServices/containers",
                     "apiVersion": "2019-06-01",
@@ -129,36 +129,36 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
             "name": "[concat(parameters('storageAccountName'), '/blobServices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "apiVersion": "2017-05-01-preview",
             "properties": {
-              "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
-              "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
-              "logs": [
-                  {
-                      "category": "StorageRead",
-                      "enabled": false
-                  },
-                  {
-                      "category": "StorageWrite",
-                      "enabled": true
-                  },
-                  {
-                      "category": "StorageDelete",
-                      "enabled": true
-                  }
-              ],
-              "metrics": [
-                  {
-                      "category": "Transaction",
-                      "enabled": true
-                  }
-              ]
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
+                "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
+                "logs": [
+                    {
+                        "category": "StorageRead",
+                        "enabled": true
+                    },
+                    {
+                        "category": "StorageWrite",
+                        "enabled": true
+                    },
+                    {
+                        "category": "StorageDelete",
+                        "enabled": true
+                    }
+                ],
+                "metrics": [
+                    {
+                        "category": "Transaction",
+                        "enabled": true
+                    }
+                ]
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/queueservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {
@@ -187,7 +187,7 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/tableservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-MNT-005 

 **Violation Description:** 

 Storage Logging records details of requests (read, write, and delete operations) against your Azure blobs. The logs include additional information such as:<br>- Timing and server latency.<br>- Success or failure, and HTTP status code.<br>- Authentication details<br><br>This policy identifies Azure storage accounts that do not have logging enabled for blobs. As a best practice, enable logging for read, write, and delete request types on blobs. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL Server by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/diagnosticsettings' target='_blank'>here</a>. Should be enabled for blobs