### PR TITLE
Fixed PR-AZR-ARM-MNT-001: Activity log alerts settings should be enabled

### DIFF
--- a/activitylogalets/azuredeploy.json
+++ b/activitylogalets/azuredeploy.json
@@ -4,7 +4,7 @@
   "parameters": {
     "actionGroupName": {
       "type": "string",
-      "defaultValue":  "autoscaleActionGroup",
+      "defaultValue": "autoscaleActionGroup",
       "minLength": 1,
       "metadata": {
         "description": "Name for the Action group."
@@ -60,7 +60,7 @@
         "[parameters('actionGroupName')]"
       ],
       "properties": {
-        "enabled": false,
+        "enabled": true,
         "scopes": [
           "[subscription().id]"
         ],


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-MNT-001 

 **Violation Description:** 

 Activity log alerts are alerts that activate when a new activity log event occurs that matches the conditions specified in the alert. Based on the order and volume of the events recorded in Azure activity log, the alert rule will fire. Activity log alert rules are Azure resources, so they can be created by using an Azure Resource Manager template.  

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for Activity Log Alert by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/2017-04-01/activitylogalerts' target='_blank'>here</a>