### PR TITLE
Fixed PR-AZR-ARM-AKS-002: Azure AKS cluster HTTP application routing should be disabled

### DIFF
--- a/AKS/aks.azuredeploy.parameters.json
+++ b/AKS/aks.azuredeploy.parameters.json
@@ -27,7 +27,7 @@
             "value": false
         },
         "enableHttpApplicationRouting": {
-            "value": true
+            "value": false
         },
         "enableAzurePolicy": {
             "value": false
@@ -65,13 +65,13 @@
         "acrResourceGroup": {
             "value": "Prancer"
         },
-        "VirtualNetworkRGName":{
+        "VirtualNetworkRGName": {
             "value": "Prancer"
         },
-        "VirtualNetworkName":{
+        "VirtualNetworkName": {
             "value": "prancer-vnet"
         },
-        "SubnetName":{
+        "SubnetName": {
             "value": "AKS"
         },
         "aadProfileManaged": {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-002 

 **Violation Description:** 

 The HTTP application routing add-on is designed to let you quickly create an ingress controller and access your applications. This add-on is not currently designed for use in a production environment and is not recommended for production use. For production-ready ingress deployments that include multiple replicas and TLS support, see Create an HTTPS ingress controller. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a> for addonProfiles.httpApplicationRouting.enabled