### PR TITLE
Fixed PR-AZR-ARM-AGW-003: Ensure Application Gateway is using Https protocol

### DIFF
--- a/APP_GW/appgw.azuredeploy.json
+++ b/APP_GW/appgw.azuredeploy.json
@@ -40,39 +40,39 @@
             "type": "bool",
             "defaultValue": false,
             "metadata": {
-            "description": "WAF Enabled"
+                "description": "WAF Enabled"
             }
         },
         "wafMode": {
             "type": "string",
             "allowedValues": [
-            "Detection",
-            "Prevention"
+                "Detection",
+                "Prevention"
             ],
             "defaultValue": "Detection",
             "metadata": {
-            "description": "WAF Mode"
+                "description": "WAF Mode"
             }
         },
         "wafRuleSetType": {
             "type": "string",
             "allowedValues": [
-            "OWASP"
+                "OWASP"
             ],
             "defaultValue": "OWASP",
             "metadata": {
-            "description": "WAF Rule Set Type"
+                "description": "WAF Rule Set Type"
             }
         },
         "wafRuleSetVersion": {
             "type": "string",
             "allowedValues": [
-            "2.2.9",
-            "3.0"
+                "2.2.9",
+                "3.0"
             ],
             "defaultValue": "3.0",
             "metadata": {
-            "description": "WAF Rule Set Version"
+                "description": "WAF Rule Set Version"
             }
         }
     },
@@ -165,7 +165,7 @@
                             "frontendPort": {
                                 "id": "[concat(variables('applicationGatewayId'), '/frontendPorts/port_80')]"
                             },
-                            "protocol": "Http",
+                            "protocol": "Https",
                             "sslCertificate": null
                         }
                     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AGW-003 

 **Violation Description:** 

 Application Gateway allows seting network protocols Http and Https. It is highly recommended to use Https protocol for secure connections. 

 **How to Fix:** 

 For resource type 'Microsoft.network/applicationgateways' make sure 'properties.protocol' under 'properties.httpListeners' exists and the value is set to 'Https' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#' target='_blank'>here</a> for details.