### PR TITLE
Fixed PR-AZR-ARM-AKS-003: Azure AKS cluster monitoring should be enabled

### DIFF
--- a/AKS/aks.azuredeploy.json
+++ b/AKS/aks.azuredeploy.json
@@ -97,7 +97,7 @@
         },
         "enableOmsAgent": {
             "type": "bool",
-            "defaultValue": false,
+            "defaultValue": true,
             "metadata": {
                 "description": "Boolean flag to turn on and off omsagent addon."
             }
@@ -198,50 +198,50 @@
             "type": "string"
         },
         "aadProfileManaged": {
-          "defaultValue": false,
-          "type": "bool",
-          "metadata": {
-            "description": "Specifies whether to enable managed AAD integration."
-          }
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether to enable managed AAD integration."
+            }
         },
         "aadProfileEnableAzureRBAC": {
-          "defaultValue": false,
-          "type": "bool",
-          "metadata": {
-            "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
-          }
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
+            }
         },
         "aadProfileAdminGroupObjectIDs": {
-          "defaultValue": [],
-          "type": "array",
-          "metadata": {
-            "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
-          }
+            "defaultValue": [],
+            "type": "array",
+            "metadata": {
+                "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
+            }
         },
         "clientAppID": {
             "type": "string",
             "metadata": {
-              "description": "The client AAD application ID."
+                "description": "The client AAD application ID."
             }
         },
         "serverAppID": {
             "type": "string",
             "metadata": {
-              "description": "The server AAD application ID."
+                "description": "The server AAD application ID."
             }
         },
         "serverAppSecret": {
             "type": "string",
             "metadata": {
-              "description": "The server AAD application secret."
+                "description": "The server AAD application secret."
             }
         },
         "aadProfileTenantId": {
-          "defaultValue": "[subscription().tenantId]",
-          "type": "string",
-          "metadata": {
-            "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
-          }
+            "defaultValue": "[subscription().tenantId]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
+            }
         }
     },
     "variables": {
@@ -282,13 +282,13 @@
                     "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]"
                 },
                 "aadProfile": {
-                  "managed": "[parameters('aadProfileManaged')]",
-                  "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
-                  "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
-                  "clientAppID": "[parameters('clientAppID')]",
-                  "serverAppID": "[parameters('serverAppID')]",
-                  "serverAppSecret": "[parameters('serverAppSecret')]",
-                  "tenantID": "[parameters('aadProfileTenantId')]"
+                    "managed": "[parameters('aadProfileManaged')]",
+                    "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
+                    "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
+                    "clientAppID": "[parameters('clientAppID')]",
+                    "serverAppID": "[parameters('serverAppID')]",
+                    "serverAppSecret": "[parameters('serverAppSecret')]",
+                    "tenantID": "[parameters('aadProfileTenantId')]"
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
@@ -333,9 +333,7 @@
                         {
                             "type": "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments",
                             "apiVersion": "2017-05-01",
-                            
                             "name": "[concat(parameters('VirtualNetworkName'), '/', parameters('SubnetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name))]",
-                            
                             "properties": {
                                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
                                 "principalId": "[reference(parameters('resourceName')).identityProfile.kubeletidentity.objectId]",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-003 

 **Violation Description:** 

 Azure Monitor for containers gives you performance visibility by collecting memory and processor metrics from controllers, nodes, and containers that are available in Kubernetes through the Metrics API. Container logs are also collected. After you enable monitoring from Kubernetes clusters, metrics and logs are automatically collected for you through a containerized version of the Log Analytics agent for Linux. Metrics are written to the metrics store and log data is written to the logs store associated with your Log Analytics workspace. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a> for addonProfiles.omsagent.enabled