### PR TITLE
Fixed PR-AZR-ARM-AKS-004: Azure AKS cluster pool profile count should contain 3 nodes or more

### DIFF
--- a/AKS/aks.azuredeploy.json
+++ b/AKS/aks.azuredeploy.json
@@ -198,50 +198,50 @@
             "type": "string"
         },
         "aadProfileManaged": {
-          "defaultValue": false,
-          "type": "bool",
-          "metadata": {
-            "description": "Specifies whether to enable managed AAD integration."
-          }
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether to enable managed AAD integration."
+            }
         },
         "aadProfileEnableAzureRBAC": {
-          "defaultValue": false,
-          "type": "bool",
-          "metadata": {
-            "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
-          }
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
+            }
         },
         "aadProfileAdminGroupObjectIDs": {
-          "defaultValue": [],
-          "type": "array",
-          "metadata": {
-            "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
-          }
+            "defaultValue": [],
+            "type": "array",
+            "metadata": {
+                "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
+            }
         },
         "clientAppID": {
             "type": "string",
             "metadata": {
-              "description": "The client AAD application ID."
+                "description": "The client AAD application ID."
             }
         },
         "serverAppID": {
             "type": "string",
             "metadata": {
-              "description": "The server AAD application ID."
+                "description": "The server AAD application ID."
             }
         },
         "serverAppSecret": {
             "type": "string",
             "metadata": {
-              "description": "The server AAD application secret."
+                "description": "The server AAD application secret."
             }
         },
         "aadProfileTenantId": {
-          "defaultValue": "[subscription().tenantId]",
-          "type": "string",
-          "metadata": {
-            "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
-          }
+            "defaultValue": "[subscription().tenantId]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
+            }
         }
     },
     "variables": {
@@ -262,7 +262,7 @@
                     {
                         "name": "prancer",
                         "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
-                        "count": 1,
+                        "count": 3,
                         "vmSize": "Standard_DS2_v2",
                         "osType": "Linux",
                         "storageProfile": "ManagedDisks",
@@ -282,13 +282,13 @@
                     "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]"
                 },
                 "aadProfile": {
-                  "managed": "[parameters('aadProfileManaged')]",
-                  "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
-                  "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
-                  "clientAppID": "[parameters('clientAppID')]",
-                  "serverAppID": "[parameters('serverAppID')]",
-                  "serverAppSecret": "[parameters('serverAppSecret')]",
-                  "tenantID": "[parameters('aadProfileTenantId')]"
+                    "managed": "[parameters('aadProfileManaged')]",
+                    "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
+                    "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
+                    "clientAppID": "[parameters('clientAppID')]",
+                    "serverAppID": "[parameters('serverAppID')]",
+                    "serverAppSecret": "[parameters('serverAppSecret')]",
+                    "tenantID": "[parameters('aadProfileTenantId')]"
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
@@ -333,9 +333,7 @@
                         {
                             "type": "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments",
                             "apiVersion": "2017-05-01",
-                            
                             "name": "[concat(parameters('VirtualNetworkName'), '/', parameters('SubnetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name))]",
-                            
                             "properties": {
                                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
                                 "principalId": "[reference(parameters('resourceName')).identityProfile.kubeletidentity.objectId]",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-004 

 **Violation Description:** 

 Ensure your AKS cluster pool profile count contains 3 or more nodes. This is recommended for a more resilient cluster. (Clusters smaller than 3 may experience downtime during upgrades.)<br><br>This policy checks the size of your cluster pool profiles and alerts if there are fewer than 3 nodes. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a>. Set minCount for Minimum number of nodes for auto-scaling to 3