### PR TITLE
Fixed PR-AZR-ARM-STR-001: Soft delete on blob service should be enabled

### DIFF
--- a/storage/StorageB/deploy.json
+++ b/storage/StorageB/deploy.json
@@ -113,7 +113,7 @@
             },
             "properties": {
                 "deleteRetentionPolicy": {
-                    "enabled": false
+                    "enabled": true
                 }
             }
         },
@@ -182,7 +182,8 @@
                 },
                 "accessTier": "Cool"
             }
-        },{
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[parameters('storageAccountName3')]",
@@ -195,9 +196,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-  
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Allow"
                 },
                 "supportsHttpsTrafficOnly": false,


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-001 

 **Violation Description:** 

 The blob service properties for blob soft delete. It helps to restore removed blob within configured retention days 

 **How to Fix:** 

 For resource type "Microsoft.storage/storageaccounts/blobservices" make sure properties.deleteRetentionPolicy.enabled exists and value is set to true .<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts/blobservices' target='_blank'>here</a> for details.