### PR TITLE
Fixed PR-AZR-ARM-STR-002: Soft delete on blob service container should be enabled

### DIFF
--- a/storage/StorageB/deploy.json
+++ b/storage/StorageB/deploy.json
@@ -114,6 +114,9 @@
             "properties": {
                 "deleteRetentionPolicy": {
                     "enabled": false
+                },
+                "containerDeleteRetentionPolicy": {
+                    "enabled": true
                 }
             }
         },
@@ -182,7 +185,8 @@
                 },
                 "accessTier": "Cool"
             }
-        },{
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[parameters('storageAccountName3')]",
@@ -195,9 +199,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-  
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Allow"
                 },
                 "supportsHttpsTrafficOnly": false,


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-002 

 **Violation Description:** 

 The blob service properties for container soft delete. It helps to restore removed blob containers within configured retention days. 

 **How to Fix:** 

 For resource type "Microsoft.storage/storageaccounts/blobservices" make sure properties.containerDeleteRetentionPolicy.enabled exists and value is set to true .<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts/blobservices' target='_blank'>here</a> for details.