### PR TITLE
Fixed PR-AZR-ARM-SQL-003: SQL managedInstances should be integrated with Azure Active Directory for administration

### DIFF
--- a/SQL/SQL-Instance/sqlinstance.azuredeploy.json
+++ b/SQL/SQL-Instance/sqlinstance.azuredeploy.json
@@ -113,10 +113,10 @@
             "apiVersion": "2021-02-01-preview",
             "name": "ActiveDirectory",
             "properties": {
-              "administratorType": "",
-              "login": "[parameters('administratorLogin')]",
-              "sid": "[parameters('administratorLoginPassword')]",
-              "tenantId": "[parameters('aadTenantId')]"
+                "administratorType": "ActiveDirectory",
+                "login": "[parameters('administratorLogin')]",
+                "sid": "[parameters('administratorLoginPassword')]",
+                "tenantId": "[parameters('aadTenantId')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-003 

 **Violation Description:** 

 Checks to ensure that SQL managedInstances are configured with Active Directory admin authentication. Azure Active Directory (Azure AD) authentication is a mechanism for connecting to Azure SQL Database, Azure SQL Managed Instance, and Synapse SQL in Azure Synapse Analytics by using identities in Azure AD. With Azure AD authentication, you can centrally manage the identities of database users and other Microsoft services in one central location. Central ID management provides a single place to manage database users and simplifies permission management. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL managedInstances by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/managedinstances/administrators?tabs=json' target='_blank'>here</a>. administratorType should be ActiveDirectory