### PR TITLE
Fixed PR-AZR-ARM-NSG-015: Azure Network Security Group (NSG) should not allow traffic from internet on port 3389

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -37,7 +37,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 101,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -381,7 +381,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 120,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -399,7 +399,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "UDP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 121,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +471,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-015 

 **Violation Description:** 

 Blocking RDP port 3389 will protect users from attacks like account compromise, Denial of service and ransomware. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>