### PR TITLE
Fixed PR-AZR-ARM-NSG-020: Azure Network Security Group should not allow mSQL (TCP Port 4333)

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -145,7 +145,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 107,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -381,7 +381,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 120,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +471,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-020 

 **Violation Description:** 

 This policy detects any NSG rule that allows MSQL traffic on TCP port 4333 from the internet. Review your list of NSG rules to ensure that your resources are not exposed.<br>As a best practice, restrict MSQL solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>