### PR TITLE
Fixed PR-AZR-ARM-NSG-025: Azure Network Security Group allows SQLServer (TCP Port 1433 and UDP Port 1434)

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -253,7 +253,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "UDP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 113,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -399,7 +399,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "UDP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 121,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +471,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-025 

 **Violation Description:** 

 This policy detects any NSG rule that allows SQLServer traffic on TCP Port 1433 and UDP Port 1434 from the internet. Review your list of NSG rules to ensure that your resources are not exposed._x005F<br>As a best practice, restrict SQLServer solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>