### PR TITLE
Fixed PR-AZR-ARM-NSG-027: Azure Network Security Group should not allow VNC Listener (TCP Port 5500)

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -307,7 +307,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 116,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -381,7 +381,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 120,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +471,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-027 

 **Violation Description:** 

 This policy detects any NSG rule that allows VNC Listener traffic on TCP port 5500 from the internet. Review your list of NSG rules to ensure that your resources are not exposed.<br>As a best practice, restrict VNC Listener solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>