### PR TITLE
Fixed PR-AZR-ARM-NSG-029: Azure Network Security Group should not allow Windows RPC (TCP Port 135)

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -343,7 +343,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 118,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -381,7 +381,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 120,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +471,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-029 

 **Violation Description:** 

 This policy detects any NSG rule that allows Windows RPC traffic on TCP port 135 from the internet. Review your list of NSG rules to ensure that your resources are not exposed.<br>As a best practice, restrict Windows RPC solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>