### PR TITLE
Fixed PR-AZR-ARM-NSG-030: Azure Network Security Group with Outbound rule to should not allow all traffic to any source

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -507,7 +507,7 @@
             "properties": {
               "description": "allow outbound traffic on any source",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 128,
               "direction": "Outbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-030 

 **Violation Description:** 

 This policy identifies NSGs which allows outgoing traffic to any source. A network security group contains a list of security rules that allow or deny inbound or outbound network traffic based on source or destination IP address, port, and protocol. As a best practice, it is recommended to configure NSGs to restrict traffic to known sources on authorized protocols and ports. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>