### PR TITLE
Fixed PR-AZR-ARM-SQL-028: Ensure Geo-redundant backup is enabled on PostgreSQL database server.

### DIFF
--- a/postgresql/azuredeploy.json
+++ b/postgresql/azuredeploy.json
@@ -86,7 +86,7 @@
     },
     "geoRedundantBackup": {
       "type": "string",
-      "defaultValue": "Disabled",
+      "defaultValue": "Enabled",
       "metadata": {
         "description": "Geo-Redundant Backup setting"
       }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-028 

 **Violation Description:** 

 Azure Database for PostgreSQL provides the flexibility to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This provides better protection and ability to restore your server in a different region in the event of a disaster. The Basic tier only offers locally redundant backup storage. 

 **How to Fix:** 

 In Resource of type "Microsoft.dbforpostgresql/servers" make sure properties.storageProfile.geoRedundantBackup exists and value is set to "Enabled".<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/servers' target='_blank'>here</a> for details.