### PR TITLE
Fixed PR-AZR-ARM-SQL-029: Ensure ssl enforcement is enabled on PostgreSQL Database Server.

### DIFF
--- a/postgresql/azuredeploy.json
+++ b/postgresql/azuredeploy.json
@@ -194,7 +194,8 @@
           "storageMB": "[parameters('skuSizeMB')]",
           "backupRetentionDays": "[parameters('backupRetentionDays')]",
           "geoRedundantBackup": "[parameters('geoRedundantBackup')]"
-        }
+        },
+        "sslEnforcement": "enabled"
       },
       "resources": [
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-029 

 **Violation Description:** 

 Enable SSL connection on PostgreSQL Servers. Rationale: SSL connectivity helps to provide a new layer of security, by connecting database server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between database server and client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and application. 

 **How to Fix:** 

 In Resource of type "Microsoft.dbforpostgresql/servers" make sure properties.sslEnforcement exists and value is set to "Enabled".<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/servers' target='_blank'>here</a> for details.