### PR TITLE
Fixed PR-AZR-ARM-SQL-041: SQL Managed Instance should have public endpoint access disabled

### DIFF
--- a/SQL/SQL-Instance/sqlinstance.azuredeploy.json
+++ b/SQL/SQL-Instance/sqlinstance.azuredeploy.json
@@ -48,7 +48,7 @@
                 "vCores": 4,
                 "storageSizeInGB": 32,
                 "collation": "SQL_Latin1_General_CP1_CI_AS",
-                "publicDataEndpointEnabled": true,
+                "publicDataEndpointEnabled": false,
                 "proxyOverride": "Proxy",
                 "timezoneId": "UTC",
                 "maintenanceConfigurationId": "/subscriptions/d34d6141-7a19-****-****-************/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
@@ -113,10 +113,10 @@
             "apiVersion": "2021-02-01-preview",
             "name": "ActiveDirectory",
             "properties": {
-              "administratorType": "",
-              "login": "[parameters('administratorLogin')]",
-              "sid": "[parameters('administratorLoginPassword')]",
-              "tenantId": "[parameters('aadTenantId')]"
+                "administratorType": "",
+                "login": "[parameters('administratorLogin')]",
+                "sid": "[parameters('administratorLoginPassword')]",
+                "tenantId": "[parameters('aadTenantId')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-041 

 **Violation Description:** 

 Always use Private Endpoint for Azure SQL Database and SQL Managed Instance 

 **How to Fix:** 

 IN ARM template make sure 'properties.publicDataEndpointEnabled' does not exist or if exist set value 'false' to 'properties.publicDataEndpointEnabled' under resource of type 'microsoft.sql/managedinstances'. Please Visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/managedinstances' target='_blank'>here</a> for details.