### PR TITLE
Fixed PR-AZR-ARM-STR-008: Ensure critical data storage in Storage Account is encrypted with Customer Managed Key

### DIFF
--- a/storage/StorageC/storage.azuredeploy.json
+++ b/storage/StorageC/storage.azuredeploy.json
@@ -6,31 +6,31 @@
             "type": "string",
             "metadata": {
                 "description": "Location of the storagr account"
-              }
+            }
         },
         "storageAccountName": {
             "type": "string",
             "metadata": {
                 "description": "Name of the storage account"
-              }
+            }
         },
         "accountType": {
             "type": "string",
             "metadata": {
                 "description": "Type of account i.e Standard/Premium LRS/GRS"
-              }
+            }
         },
         "kind": {
             "type": "string",
             "metadata": {
                 "description": "Kind of storag account required for teh storage account"
-              }
+            }
         },
         "accessTier": {
             "type": "string",
             "metadata": {
                 "description": "Access Tier of the storage account default Hot, will chnage it to the Cold "
-              }
+            }
         },
         "minimumTlsVersion": {
             "type": "string"
@@ -42,7 +42,7 @@
             "type": "bool",
             "metadata": {
                 "description": "Allow Blob public access to Blob storage"
-              }
+            }
         },
         "networkAclsBypass": {
             "type": "string"
@@ -79,7 +79,7 @@
                             "enabled": false
                         }
                     },
-                    "keySource": "Microsoft.Storage"
+                    "keySource": "Microsoft.Keyvault"
                 }
             },
             "dependsOn": [],


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-008 

 **Violation Description:** 

 By default, data in the storage account is encrypted using Microsoft Managed Keys at rest. All Azure Storage resources are encrypted, including blobs, disks, files, queues, and tables. All object metadata is also encrypted. However, if you want to control and manage this encryption key yourself, you can specify a customer-managed key, that key is used to protect and control access to the key that encrypts your data. You can also choose to automatically update the key version used for Azure Storage encryption whenever a new version is available in the associated Key Vault. 

 **How to Fix:** 

 In Resource of type "Microsoft.storage/storageaccounts" make sure properties.encryption.keySource exists and value is set to "Microsoft.Keyvault".<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a> for details.