### PR TITLE
Fixed PR-AZR-ARM-STR-008: Ensure critical data storage in Storage Account is encrypted with Customer Managed Key

### DIFF
--- a/storage/StorageA/blob.azuredeploy.json
+++ b/storage/StorageA/blob.azuredeploy.json
@@ -35,7 +35,7 @@
         "containerName": {
             "type": "string"
         },
-        "workspaceName" : {
+        "workspaceName": {
             "type": "string",
             "defaultValue": "GEN-UNIQUE"
         },
@@ -72,10 +72,10 @@
                             "enabled": false
                         }
                     },
-                    "keySource": "Microsoft.Storage"
+                    "keySource": "Microsoft.Keyvault"
                 }
             },
-            "resources":[
+            "resources": [
                 {
                     "type": "blobServices/containers",
                     "apiVersion": "2019-06-01",
@@ -129,36 +129,36 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
             "name": "[concat(parameters('storageAccountName'), '/blobServices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "apiVersion": "2017-05-01-preview",
             "properties": {
-              "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
-              "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
-              "logs": [
-                  {
-                      "category": "StorageRead",
-                      "enabled": false
-                  },
-                  {
-                      "category": "StorageWrite",
-                      "enabled": true
-                  },
-                  {
-                      "category": "StorageDelete",
-                      "enabled": true
-                  }
-              ],
-              "metrics": [
-                  {
-                      "category": "Transaction",
-                      "enabled": true
-                  }
-              ]
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
+                "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
+                "logs": [
+                    {
+                        "category": "StorageRead",
+                        "enabled": false
+                    },
+                    {
+                        "category": "StorageWrite",
+                        "enabled": true
+                    },
+                    {
+                        "category": "StorageDelete",
+                        "enabled": true
+                    }
+                ],
+                "metrics": [
+                    {
+                        "category": "Transaction",
+                        "enabled": true
+                    }
+                ]
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/queueservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {
@@ -187,7 +187,7 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/tableservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-008 

 **Violation Description:** 

 By default, data in the storage account is encrypted using Microsoft Managed Keys at rest. All Azure Storage resources are encrypted, including blobs, disks, files, queues, and tables. All object metadata is also encrypted. However, if you want to control and manage this encryption key yourself, you can specify a customer-managed key, that key is used to protect and control access to the key that encrypts your data. You can also choose to automatically update the key version used for Azure Storage encryption whenever a new version is available in the associated Key Vault. 

 **How to Fix:** 

 In Resource of type "Microsoft.storage/storageaccounts" make sure properties.encryption.keySource exists and value is set to "Microsoft.Keyvault".<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a> for details.