### PR TITLE
Fixed PR-AZR-ARM-DBK-001: Azure Databricks shoud not use public IP address

### DIFF
--- a/databricks-workspace/azuredeploy.json
+++ b/databricks-workspace/azuredeploy.json
@@ -60,6 +60,9 @@
           "enableNoPublicIp": {
             "value": "[parameters('disablePublicIp')]"
           }
+        },
+        "enableNoPublicIp": {
+          "value": true
         }
       }
     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-DBK-001 

 **Violation Description:** 

 Azure Databricks is a data analytics platform optimized for the Microsoft Azure cloud services platform. This policy will identify Databricks which does not have public ip disabled and warn. 

 **How to Fix:** 

 In Resource of type "microsoft.databricks/workspaces" make sure properties.parameters.enableNoPublicIp exist and its value set to true.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.databricks/workspaces?tabs=json' target='_blank'>here</a> for details.