### PR TITLE
Fixed PR-AZR-ARM-WEB-001: Ensure Azure App Service Web App enforce https connection

### DIFF
--- a/webapp-windows-aspnet/azuredeploy.json
+++ b/webapp-windows-aspnet/azuredeploy.json
@@ -90,7 +90,8 @@
                     "alwaysOn": "[variables('alwaysOn')]"
                 },
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "clientAffinityEnabled": true
+                "clientAffinityEnabled": true,
+                "httpsOnly": true
             }
         },
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-WEB-001 

 **Violation Description:** 

 Azure Web Apps by default allow sites to run under both HTTP and HTTPS and can be accessed by anyone using non-secure HTTP links. Non-secure HTTP requests can be restricted and all HTTP requests redirected to the secure HTTPS port. We recommend you enforce HTTPS-only traffic to increase security. This will redirect all non-secure HTTP requests to HTTPS ports. HTTPS uses the SSL/TLS protocol to provide a secure connection, which is both encrypted and authenticated. 

 **How to Fix:** 

 For Resource type 'microsoft.web/sites' make sure httpsOnly exists and the value is set to true.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites' target='_blank'>here</a> for more details.