### PR TITLE
Fixed PR-AZR-ARM-WEB-003: Web App should has incoming client certificates enabled

### DIFF
--- a/webapp-windows-aspnet/azuredeploy.json
+++ b/webapp-windows-aspnet/azuredeploy.json
@@ -90,7 +90,8 @@
                     "alwaysOn": "[variables('alwaysOn')]"
                 },
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "clientAffinityEnabled": true
+                "clientAffinityEnabled": true,
+                "clientCertEnabled": true
             }
         },
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-WEB-003 

 **Violation Description:** 

 Client certificates allow the Web App to require a certificate for incoming requests. Only clients that have a valid certificate will be able to reach the app. The TLS mutual authentication technique in enterprise environments ensures the authenticity of clients to the server. If incoming client certificates are enabled only an authenticated client with valid certificates can access the app. 

 **How to Fix:** 

 For Resource type 'microsoft.web/sites' make sure clientCertEnabled exists and the value is set to true.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites' target='_blank'>here</a> for more details.