### PR TITLE
Fixed PR-AZR-ARM-SQL-016: Ensure ssl enforcement is enabled on MySQL server Database Server.

### DIFF
--- a/mysql/azuredeploy.json
+++ b/mysql/azuredeploy.json
@@ -192,7 +192,8 @@
           "storageMB": "[parameters('skuSizeMB')]",
           "backupRetentionDays": "[parameters('backupRetentionDays')]",
           "geoRedundantBackup": "[parameters('geoRedundantBackup')]"
-        }
+        },
+        "sslEnforcement": "Enabled"
       },
       "resources": [
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-016 

 **Violation Description:** 

 Enable SSL connection on MySQL Servers databases. Rationale: SSL connectivity helps to provide a new layer of security, by connecting database server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between database server and client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and application. 

 **How to Fix:** 

 For Resource type 'microsoft.dbformysql/servers' make sure sslEnforcement exists and the value is set to 'Enabled'.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.dbformysql/servers' target='_blank'>here</a> for more details.