### PR TITLE
Fixed PR-AZR-ARM-MNT-009: activity log retention should be set to 365 days or greater

### DIFF
--- a/logprofiler/azuredeploy.parameters.json
+++ b/logprofiler/azuredeploy.parameters.json
@@ -18,7 +18,7 @@
             "value": true
         },
         "days": {
-            "value": 90
+            "value": 365
         }
     }
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-MNT-009 

 **Violation Description:** 

 Specifies the retention policy for the log. We recommend you set activity log retention for 365 days or greater. (A value of 0 will retain the events indefinitely.) 

 **How to Fix:** 

 For Resource type 'microsoft.insights/logprofiles' make sure retentionPolicy.days exists and greater than 365 and retentionPolicy.enabled exists and the value is set to true or retentionPolicy.days exists and set to 0 and retentionPolicy.enabled exists and the value is set to false.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/logprofiles' target='_blank'>here</a> for more details.