### PR TITLE
Fixed PR-AZR-ARM-AGW-005: Ensure Application Gateway Backend is using Https protocol

### DIFF
--- a/APP_GW/appgw.azuredeploy.json
+++ b/APP_GW/appgw.azuredeploy.json
@@ -40,39 +40,39 @@
             "type": "bool",
             "defaultValue": false,
             "metadata": {
-            "description": "WAF Enabled"
+                "description": "WAF Enabled"
             }
         },
         "wafMode": {
             "type": "string",
             "allowedValues": [
-            "Detection",
-            "Prevention"
+                "Detection",
+                "Prevention"
             ],
             "defaultValue": "Detection",
             "metadata": {
-            "description": "WAF Mode"
+                "description": "WAF Mode"
             }
         },
         "wafRuleSetType": {
             "type": "string",
             "allowedValues": [
-            "OWASP"
+                "OWASP"
             ],
             "defaultValue": "OWASP",
             "metadata": {
-            "description": "WAF Rule Set Type"
+                "description": "WAF Rule Set Type"
             }
         },
         "wafRuleSetVersion": {
             "type": "string",
             "allowedValues": [
-            "2.2.9",
-            "3.0"
+                "2.2.9",
+                "3.0"
             ],
             "defaultValue": "3.0",
             "metadata": {
-            "description": "WAF Rule Set Version"
+                "description": "WAF Rule Set Version"
             }
         }
     },
@@ -149,7 +149,7 @@
                         "name": "Pancer_Http",
                         "properties": {
                             "port": 80,
-                            "protocol": "Http",
+                            "protocol": "Https",
                             "cookieBasedAffinity": "Disabled",
                             "requestTimeout": 20
                         }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AGW-005 

 **Violation Description:** 

 Application Gateway allows setting backend network protocols Http and Https. It is highly recommended to use Https protocol for secure connections. 

 **How to Fix:** 

 For resource type 'microsoft.network/applicationgateways' make sure 'properties.protocol' has value 'https' under 'backendHttpSettingsCollection' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#applicationgatewaybackendhttpsettings' target='_blank'>here</a> for details.