### PR TITLE
Fixed PR-AZR-ARM-SQL-027: Azure SQL Server advanced data security should send alerts to subscription administrators

### DIFF
--- a/SQL/SQL-DB/sqldb.azuredeploy.json
+++ b/SQL/SQL-DB/sqldb.azuredeploy.json
@@ -86,22 +86,22 @@
                 "minCapacity": "[parameters('minCapacity')]",
                 "autoPauseDelay": "[parameters('autoPauseDelay')]"
             },
-            "resources":[
+            "resources": [
                 {
-                        "condition": "[parameters('enableVA')]",
-                        "type": "vulnerabilityAssessments",
-                        "apiVersion": "2018-06-01-preview",
-                        "name": "Default",
-                        "properties": {
-                            "storageContainerPath": "",
-                            "storageAccountAccessKey": "",
-                            "recurringScans": {
-                                "isEnabled": false,
-                                "emailSubscriptionAdmins": false
-                            }
+                    "condition": "[parameters('enableVA')]",
+                    "type": "vulnerabilityAssessments",
+                    "apiVersion": "2018-06-01-preview",
+                    "name": "Default",
+                    "properties": {
+                        "storageContainerPath": "",
+                        "storageAccountAccessKey": "",
+                        "recurringScans": {
+                            "isEnabled": false,
+                            "emailSubscriptionAdmins": true
                         }
-                  },
-                  {
+                    }
+                },
+                {
                     "type": "auditingSettings",
                     "apiVersion": "2020-08-01-preview",
                     "name": "Default",
@@ -114,22 +114,24 @@
                         "storageAccountSubscriptionId": "",
                         "isStorageSecondaryKeyInUse": false
                     }
-                 },
-                 {
+                },
+                {
                     "type": "transparentDataEncryption",
                     "apiVersion": "2014-04-01",
                     "name": "current",
                     "properties": {
-                      "status": "[parameters('transparentDataEncryptionStatus')]"
+                        "status": "[parameters('transparentDataEncryptionStatus')]"
                     }
-                 },
-                 {
+                },
+                {
                     "type": "securityAlertPolicies",
                     "apiVersion": "2020-02-02-preview",
                     "name": "Default",
                     "properties": {
                         "state": "Disabled",
-                        "disabledAlerts": ["Access_Anomaly"]
+                        "disabledAlerts": [
+                            "Access_Anomaly"
+                        ]
                     }
                 }
             ],
@@ -143,7 +145,7 @@
             "apiVersion": "2014-04-01",
             "name": "current",
             "properties": {
-              "status": "[parameters('transparentDataEncryptionStatus')]"
+                "status": "[parameters('transparentDataEncryptionStatus')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-027 

 **Violation Description:** 

 Advanced data security (ADS) provides a set of advanced SQL security capabilities, including vulnerability assessment, threat detection, and data discovery and classification.<br><br>This policy identifies Azure SQL Servers that are not enabled with ADS. As a best practice, enable ADS so that the subscription admin can receive email alerts when anomalous activities are detected on the SQL Servers. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL Server by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2017-03-01-preview/servers/databases/vulnerabilityassessments' target='_blank'>here</a>. Specifies that the schedule scan notification will be is sent to the subscription administrators.