### PR TITLE
Fixed PR-AZR-ARM-STR-010: Ensure that Storage Account should not allow public access to all blobs or containers

### DIFF
--- a/storage/StorageA/blob.azuredeploy.parameters.json
+++ b/storage/StorageA/blob.azuredeploy.parameters.json
@@ -24,7 +24,7 @@
             "value": false
         },
         "allowBlobPublicAccess": {
-            "value": true
+            "value": false
         },
         "networkAclsBypass": {
             "value": "None"
@@ -32,7 +32,7 @@
         "networkAclsDefaultAction": {
             "value": "Allow"
         },
-        "containerName":{
+        "containerName": {
             "value": "prancerstoragecontainer"
         }
     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-010 

 **Violation Description:** 

 This policy will identify which Storage Account has public access enabled for all blobs or containers 

 **How to Fix:** 

 In Resource of type "Microsoft.storage/storageaccounts" make sure property allowBlobPublicAccess is not exist or value set to false.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a> for details.