### PR TITLE
Fixed PR-AZR-ARM-AKS-008: Ensure AKS cluster network policies are enforced

### DIFF
--- a/AKS/aks.azuredeploy.parameters.json
+++ b/AKS/aks.azuredeploy.parameters.json
@@ -57,7 +57,7 @@
             "value": "eastus"
         },
         "networkPolicy": {
-            "value": "calico"
+            "value": "azure"
         },
         "acrName": {
             "value": "asadsadasdas"
@@ -65,13 +65,13 @@
         "acrResourceGroup": {
             "value": "Prancer"
         },
-        "VirtualNetworkRGName":{
+        "VirtualNetworkRGName": {
             "value": "Prancer"
         },
-        "VirtualNetworkName":{
+        "VirtualNetworkName": {
             "value": "prancer-vnet"
         },
-        "SubnetName":{
+        "SubnetName": {
             "value": "AKS"
         },
         "aadProfileManaged": {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-008 

 **Violation Description:** 

 Network policy options in AKS include two ways to implement a network policy. You can choose between Azure Network Policies or Calico Network Policies. In both cases, the underlying controlling layer is based on Linux IPTables to enforce the specified policies. Policies are translated into sets of allowed and disallowed IP pairs. These pairs are then programmed as IPTable rules. 

 **How to Fix:** 

 For Resource type 'microsoft.containerservice/managedclusters' make sure networkProfile.networkPolicy exists and the value is set to `azure` or 'calico`.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a> for more details.