### PR TITLE
Fixed PR-AZR-ARM-WEB-002: Web App should uses the latest version of TLS encryption

### DIFF
--- a/webapp-windows-aspnet/azuredeploy.json
+++ b/webapp-windows-aspnet/azuredeploy.json
@@ -90,7 +90,8 @@
                     "alwaysOn": "[variables('alwaysOn')]"
                 },
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "clientAffinityEnabled": true
+                "clientAffinityEnabled": true,
+                "minTlsVersion": "1.2"
             }
         },
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-WEB-002 

 **Violation Description:** 

 App service currently allows the web app to set TLS versions 1.0, 1.1, and 1.2. For secure web app connections, it is highly recommended to only use the latest TLS 1.2 version. 

 **How to Fix:** 

 For Resource type 'microsoft.web/sites' make sure siteConfig.minTlsVersion exists and the value is set to '1.2'.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites' target='_blank'>here</a> for more details.