### PR TITLE
Fixed PR-AZR-ARM-WEB-004: Web App should use the latest version of HTTP

### DIFF
--- a/webapp-windows-aspnet/azuredeploy.json
+++ b/webapp-windows-aspnet/azuredeploy.json
@@ -90,7 +90,8 @@
                     "alwaysOn": "[variables('alwaysOn')]"
                 },
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "clientAffinityEnabled": true
+                "clientAffinityEnabled": true,
+                "http20Enabled": true
             }
         },
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-WEB-004 

 **Violation Description:** 

 We recommend you use the latest HTTP version for web apps and take advantage of any security fixes and new functionalities featured. With each software installation you can determine if a given update meets your organization's requirements. Organizations should verify the compatibility and support provided for any additional software, assessing the current version against the update revision being considered. 

 **How to Fix:** 

 For Resource type 'microsoft.web/sites' make sure siteConfig.http20Enabled exists and the value is set to true.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites' target='_blank'>here</a> for more details.