### PR TITLE
Fixed PR-AZR-ARM-AGW-004: Ensure Application Gateway frontendIPConfigurations does not have public ip configured

### DIFF
--- a/APP_GW/appgw.azuredeploy.json
+++ b/APP_GW/appgw.azuredeploy.json
@@ -40,39 +40,39 @@
             "type": "bool",
             "defaultValue": false,
             "metadata": {
-            "description": "WAF Enabled"
+                "description": "WAF Enabled"
             }
         },
         "wafMode": {
             "type": "string",
             "allowedValues": [
-            "Detection",
-            "Prevention"
+                "Detection",
+                "Prevention"
             ],
             "defaultValue": "Detection",
             "metadata": {
-            "description": "WAF Mode"
+                "description": "WAF Mode"
             }
         },
         "wafRuleSetType": {
             "type": "string",
             "allowedValues": [
-            "OWASP"
+                "OWASP"
             ],
             "defaultValue": "OWASP",
             "metadata": {
-            "description": "WAF Rule Set Type"
+                "description": "WAF Rule Set Type"
             }
         },
         "wafRuleSetVersion": {
             "type": "string",
             "allowedValues": [
-            "2.2.9",
-            "3.0"
+                "2.2.9",
+                "3.0"
             ],
             "defaultValue": "3.0",
             "metadata": {
-            "description": "WAF Rule Set Version"
+                "description": "WAF Rule Set Version"
             }
         }
     },
@@ -114,7 +114,7 @@
                         "name": "appGwPublicFrontendIp",
                         "properties": {
                             "publicIPAddress": {
-                                "id": "[variables('publicIPRef')]"
+                                "id": "Microsoft.Network/publicIPAddresses//GW_IP"
                             }
                         }
                     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AGW-004 

 **Violation Description:** 

 Application Gateway allows setting public or private ip in frontendIPConfigurations. It is highly recommended to only configure private ip in frontendIPConfigurations. 

 **How to Fix:** 

 For resource type 'microsoft.network/applicationgateways' make sure 'properties.publicIPAddress' does not exist under 'frontendIPConfigurations' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#applicationgatewayfrontendipconfiguration' target='_blank'>here</a> for details.