### PR TITLE
Fixed PR-AZR-ARM-KV-005: Azure Key Vault secrets should have an expiration date

### DIFF
--- a/azurefirewall/azuredeploy.json
+++ b/azurefirewall/azuredeploy.json
@@ -116,7 +116,11 @@
                 "[resourceId('Microsoft.Resources/deploymentScripts', 'CreateAndDeployCertificates')]"
             ],
             "properties": {
-                "value": "[reference('CreateAndDeployCertificates').outputs.interca]"
+                "value": "[reference('CreateAndDeployCertificates').outputs.interca]",
+                "attributes": {
+                    "enabled": true,
+                    "exp": 1694446700
+                }
             }
         },
         {
@@ -175,8 +179,8 @@
                         }
                     }
                 ]
-            }            
-        },        
+            }
+        },
         {
             "type": "Microsoft.Network/networkInterfaces",
             "apiVersion": "2020-07-01",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-KV-005 

 **Violation Description:** 

 This policy identifies Azure Key Vault secrets that do not have an expiratiSon date. As a best practice, set an expiration date for each secret and rotate the secret regularly. 

 **How to Fix:** 

 In Resource of type "Microsoft.KeyVault/vaults/secrets" make sure properties.attributes.exp exists and value isn't set empty.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.keyvault/vaults/secrets' target='_blank'>here</a> for details.