### PR TITLE
Fixed PR-AZR-ARM-SQL-044: Azure SQL server audit log retention should be 90 days or higher

### DIFF
--- a/SQL/SQL-Server/sql.azuredeploy.json
+++ b/SQL/SQL-Server/sql.azuredeploy.json
@@ -44,16 +44,16 @@
         "aadTenantId": {
             "type": "securestring"
         },
-        "storageAccountName" : {
+        "storageAccountName": {
             "type": "string",
             "defaultValue": "storage-account"
         },
-        "firewallRuleName" : {
-            "type" : "string",
+        "firewallRuleName": {
+            "type": "string",
             "defaultValue": "IPRange1"
         },
-        "allowPublicAccess" : {
-            "type" : "string",
+        "allowPublicAccess": {
+            "type": "string",
             "defaultValue": "0.0.0.0"
         }
     },
@@ -162,15 +162,15 @@
                     "type": "administrators",
                     "apiVersion": "2014-04-01-Preview",
                     "dependsOn": [
-                      "[concat('Microsoft.Sql/servers/', parameters('serverName'))]",
-                      "[concat('Microsoft.Sql/servers/', parameters('serverName'), '/databases/',parameters('databaseName'))]"
+                        "[concat('Microsoft.Sql/servers/', parameters('serverName'))]",
+                        "[concat('Microsoft.Sql/servers/', parameters('serverName'), '/databases/',parameters('databaseName'))]"
                     ],
                     "location": "[parameters('location')]",
                     "properties": {
-                      "administratorType": "",
-                      "login": "[parameters('administratorLogin')]",
-                      "sid": "[parameters('administratorLoginPassword')]",
-                      "tenantId": "[parameters('aadTenantId')]"
+                        "administratorType": "",
+                        "login": "[parameters('administratorLogin')]",
+                        "sid": "[parameters('administratorLoginPassword')]",
+                        "tenantId": "[parameters('aadTenantId')]"
                     }
                 },
                 {
@@ -182,7 +182,9 @@
                     ],
                     "properties": {
                         "state": "Disabled",
-                        "disabledAlerts": ["Access_Anomaly"]
+                        "disabledAlerts": [
+                            "Access_Anomaly"
+                        ]
                     }
                 },
                 {
@@ -213,7 +215,9 @@
             ],
             "properties": {
                 "state": "Disabled",
-                "disabledAlerts": ["Access_Anomaly"]
+                "disabledAlerts": [
+                    "Access_Anomaly"
+                ]
             }
         },
         {
@@ -225,7 +229,10 @@
             ],
             "properties": {
                 "state": "Disabled",
-                "disabledAlerts" : [ "Sql_Injection" , "Sql_Injection_Vulnerability" ]
+                "disabledAlerts": [
+                    "Sql_Injection",
+                    "Sql_Injection_Vulnerability"
+                ]
             }
         },
         {
@@ -253,7 +260,7 @@
                 "state": "Disabled",
                 "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2018-03-01-preview').PrimaryEndpoints.Blob]",
                 "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2018-03-01-preview').keys[0].value]",
-                "retentionDays": 30,
+                "retentionDays": 180,
                 "auditActionsAndGroups": null,
                 "storageAccountSubscriptionId": "[subscription().subscriptionId]",
                 "isStorageSecondaryKeyInUse": false
@@ -288,21 +295,21 @@
             "apiVersion": "2019-06-01-preview",
             "name": "ActiveDirectory",
             "properties": {
-              "administratorType": "",
-              "login": "[parameters('administratorLogin')]",
-              "sid": "[parameters('administratorLoginPassword')]",
-              "tenantId": "[parameters('aadTenantId')]"
+                "administratorType": "",
+                "login": "[parameters('administratorLogin')]",
+                "sid": "[parameters('administratorLoginPassword')]",
+                "tenantId": "[parameters('aadTenantId')]"
             }
         },
         {
-          "type": "Microsoft.Sql/servers/encryptionProtector",
-          "apiVersion": "2021-02-01-preview",
-          "name": "current",
-          "properties": {
-            "autoRotationEnabled": "bool",
-            "serverKeyName": "encryptionProtectorKey",
-            "serverKeyType": "ServiceManaged"
-          }
+            "type": "Microsoft.Sql/servers/encryptionProtector",
+            "apiVersion": "2021-02-01-preview",
+            "name": "current",
+            "properties": {
+                "autoRotationEnabled": "bool",
+                "serverKeyName": "encryptionProtectorKey",
+                "serverKeyType": "ServiceManaged"
+            }
         }
     ]
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-044 

 **Violation Description:** 

 Audit Logs can be used to check for anomalies and give insight into suspected breaches or misuse of information and access. We recommend you configure SQL server audit retention to be 90 days or higher. 

 **How to Fix:** 

 For Resource type 'microsoft.sql/servers/auditingsettings' make sure retentionDays exists and equal or greater than 90 days.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2021-02-01-preview/servers/auditingsettings' target='_blank'>here</a> for more details.