### PR TITLE
Fixed PR-AZR-ARM-AKS-005: Azure AKS enable role-based access control (RBAC) should be enforced

### DIFF
--- a/AKS/aks.azuredeploy.parameters.json
+++ b/AKS/aks.azuredeploy.parameters.json
@@ -18,7 +18,7 @@
             "value": "kubenet"
         },
         "enableRBAC": {
-            "value": false
+            "value": true
         },
         "enablekubeDashboard": {
             "value": true
@@ -65,13 +65,13 @@
         "acrResourceGroup": {
             "value": "Prancer"
         },
-        "VirtualNetworkRGName":{
+        "VirtualNetworkRGName": {
             "value": "Prancer"
         },
-        "VirtualNetworkName":{
+        "VirtualNetworkName": {
             "value": "prancer-vnet"
         },
-        "SubnetName":{
+        "SubnetName": {
             "value": "AKS"
         },
         "aadProfileManaged": {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-005 

 **Violation Description:** 

 To provide granular filtering of the actions that users can perform, Kubernetes uses role-based access controls (RBAC). This control mechanism lets you assign users, or groups of users, permission to do things like create or modify resources, or view logs from running application workloads. These permissions can be scoped to a single namespace, or granted across the entire AKS cluster._x005F<br>_x005F<br>This policy checks your AKS cluster RBAC setting and alerts if disabled. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a>. Set enable RBAC to true to enable Kubernetes Role-Based Access Control.