### PR TITLE
Fixed PR-AZR-ARM-AKS-009: Ensure Kubernetes Dashboard is disabled

### DIFF
--- a/AKS/aks.azuredeploy.parameters.json
+++ b/AKS/aks.azuredeploy.parameters.json
@@ -21,7 +21,7 @@
             "value": false
         },
         "enablekubeDashboard": {
-            "value": true
+            "value": false
         },
         "enablePrivateCluster": {
             "value": false
@@ -65,13 +65,13 @@
         "acrResourceGroup": {
             "value": "Prancer"
         },
-        "VirtualNetworkRGName":{
+        "VirtualNetworkRGName": {
             "value": "Prancer"
         },
-        "VirtualNetworkName":{
+        "VirtualNetworkName": {
             "value": "prancer-vnet"
         },
-        "SubnetName":{
+        "SubnetName": {
             "value": "AKS"
         },
         "aadProfileManaged": {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AKS-009 

 **Violation Description:** 

 Disable the Kubernetes dashboard on Azure Kubernetes Service 

 **How to Fix:** 

 For resource type 'microsoft.containerservice/managedclusters' make sure property 'addonProfiles.kubeDashboard.enabled' exist and its value set to 'false' to fix the issue. Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters?tabs=json' target='_blank'>here</a> for details.