### PR TITLE
Fixed PR-AZR-ARM-AGW-001: Azure Application Gateway should not allow TLSv1.1 or lower

### DIFF
--- a/APP_GW/appgw.azuredeploy.json
+++ b/APP_GW/appgw.azuredeploy.json
@@ -40,39 +40,39 @@
             "type": "bool",
             "defaultValue": false,
             "metadata": {
-            "description": "WAF Enabled"
+                "description": "WAF Enabled"
             }
         },
         "wafMode": {
             "type": "string",
             "allowedValues": [
-            "Detection",
-            "Prevention"
+                "Detection",
+                "Prevention"
             ],
             "defaultValue": "Detection",
             "metadata": {
-            "description": "WAF Mode"
+                "description": "WAF Mode"
             }
         },
         "wafRuleSetType": {
             "type": "string",
             "allowedValues": [
-            "OWASP"
+                "OWASP"
             ],
             "defaultValue": "OWASP",
             "metadata": {
-            "description": "WAF Rule Set Type"
+                "description": "WAF Rule Set Type"
             }
         },
         "wafRuleSetVersion": {
             "type": "string",
             "allowedValues": [
-            "2.2.9",
-            "3.0"
+                "2.2.9",
+                "3.0"
             ],
             "defaultValue": "3.0",
             "metadata": {
-            "description": "WAF Rule Set Version"
+                "description": "WAF Rule Set Version"
             }
         }
     },
@@ -189,7 +189,7 @@
                 ],
                 "sslPolicy": {
                     "policyType": "Custom",
-                    "minProtocolVersion": "TLSv1_1",
+                    "minProtocolVersion": "TLSv1_2",
                     "cipherSuites": [
                         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
                         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-AGW-001 

 **Violation Description:** 

 Transport Layer Security (TLS), previously known as Secure Sockets Layer (SSL), is the standard security technology for establishing an encrypted link between a web server and a browser. This link ensures that all data passed between the web server and browsers remain private and encrypted. Application gateway supports both TLS termination at the gateway as well as end to end TLS encryption. The minimum allowed TLS version should be 1.2 

 **How to Fix:** 

 For resource type 'microsoft.network/applicationgateways' make sure 'properties.sslPolicy.minProtocolVersion' exists and the value is set to 'tlsv1_2' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#' target='_blank'>here</a> for details.