### PR TITLE
Fixed PR-AZR-ARM-MNT-002: Azure Key Vault audit logging should be enabled

### DIFF
--- a/KeyVault/Keyvault.azuredeploy.json
+++ b/KeyVault/Keyvault.azuredeploy.json
@@ -6,19 +6,19 @@
             "type": "string",
             "metadata": {
                 "description": "Name of the KeyVault"
-              }
+            }
         },
         "location": {
             "type": "string",
             "metadata": {
                 "description": "Location of the Keyvault Deploy"
-              }
+            }
         },
         "sku": {
             "type": "string",
             "metadata": {
                 "description": "Mentioned the SKU of the azure Keyvault"
-              }
+            }
         },
         "accessPolicies": {
             "type": "array"
@@ -30,25 +30,25 @@
             "type": "bool",
             "metadata": {
                 "description": "Enable for Azure Virtual Machines for deployment"
-              }
+            }
         },
         "enabledForTemplateDeployment": {
             "type": "bool",
             "metadata": {
                 "description": "Enable Azure Resource Manager for template deployment"
-              }
+            }
         },
         "enabledForDiskEncryption": {
             "type": "bool",
             "metadata": {
                 "description": "Enable for Azure Disk Encryption for volume encryption"
-              }
+            }
         },
         "enableRbacAuthorization": {
             "type": "bool",
             "metadata": {
                 "description": "Enable RBAC authntication for the keyvault access"
-              }
+            }
         },
         "enableSoftDelete": {
             "type": "bool"
@@ -59,37 +59,37 @@
         "networkAcls": {
             "type": "object"
         },
-        "secretName":{
+        "secretName": {
             "type": "securestring",
             "metadata": {
                 "description": "Value for the Secrets to be store"
-              }
+            }
         },
-        "secretValue":{
+        "secretValue": {
             "type": "securestring",
             "metadata": {
                 "description": "Value for the Secrets to be store"
-              }
+            }
         },
-        "keyName":{
+        "keyName": {
             "type": "securestring",
             "metadata": {
                 "description": "Value for the Key to be store"
-              }
+            }
         },
-        "keyEnabled":{
+        "keyEnabled": {
             "type": "bool"
         },
-        "keyExp":{
+        "keyExp": {
             "type": "int"
         },
-        "keynbf":{
+        "keynbf": {
             "type": "int"
         },
-        "keyExpiryTime":{
+        "keyExpiryTime": {
             "type": "string"
         },
-        "keySize":{
+        "keySize": {
             "type": "int"
         }
     },
@@ -127,14 +127,14 @@
             "name": "[concat(parameters('keyVaultName'), '/', parameters('secretName'))]",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-              "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
             ],
             "properties": {
-              "attributes": {
-                "value": "[parameters('secretValue')]",
-                "enabled": "[parameters('keyEnabled')]",
-                "exp": "[parameters('keyExp')]"
-               }
+                "attributes": {
+                    "value": "[parameters('secretValue')]",
+                    "enabled": "[parameters('keyEnabled')]",
+                    "exp": "[parameters('keyExp')]"
+                }
             }
         },
         {
@@ -145,39 +145,39 @@
                 "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
             ],
             "properties": {
-              "attributes": {
-                "enabled": "[parameters('keyEnabled')]",
-                "exp": "[parameters('keyExp')]",
-                "nbf": "[parameters('keynbf')]"
-              },
-              "keySize": "[parameters('keySize')]",
-              "rotationPolicy": {
                 "attributes": {
-                  "expiryTime": "[parameters('keyExpiryTime')]"
+                    "enabled": "[parameters('keyEnabled')]",
+                    "exp": "[parameters('keyExp')]",
+                    "nbf": "[parameters('keynbf')]"
+                },
+                "keySize": "[parameters('keySize')]",
+                "rotationPolicy": {
+                    "attributes": {
+                        "expiryTime": "[parameters('keyExpiryTime')]"
+                    }
                 }
-              }
             }
         },
         {
-            "type" : "Microsoft.KeyVault/vaults/providers/diagnosticsettings",
+            "type": "Microsoft.KeyVault/vaults/providers/diagnosticsettings",
             "name": "LogSettings",
             "scope": "",
             "apiVersion": "2021-05-01-preview",
             "properties": {
-              "workspaceId": "",
-              "storageAccountId": "",
-              "logs": [
-                  {
-                      "category": "Auditevent",
-                      "enabled": false
-                  }
-              ],
-              "metrics": [
-                  {
-                      "category": "Transaction",
-                      "enabled": true
-                  }
-              ]
+                "workspaceId": "",
+                "storageAccountId": "",
+                "logs": [
+                    {
+                        "category": "Auditevent",
+                        "enabled": true
+                    }
+                ],
+                "metrics": [
+                    {
+                        "category": "Transaction",
+                        "enabled": true
+                    }
+                ]
             }
         }
     ],


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-MNT-002 

 **Violation Description:** 

 Azure Key Vault provide different types of logs alert events, health probe, metrics to help you manage and troubleshoot issues. This policy identifies Azure Key Vault that have diagnostics logs disabled. As a best practice, enable diagnostic logs to start collecting the data available through these logs. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for SQL Server by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/diagnosticsettings' target='_blank'>here</a>. Make sure to enable diagnostics settings for keyvault