### PR TITLE
Fixed PR-AZR-ARM-KV-005: Azure Key Vault secrets should have an expiration date

### DIFF
--- a/KeyVault/Keyvault.azuredeploy.parameters.json
+++ b/KeyVault/Keyvault.azuredeploy.parameters.json
@@ -88,28 +88,28 @@
                 "virtualNetworkRules": []
             }
         },
-        "secretName":{
+        "secretName": {
             "value": "prancer-secret"
         },
-        "secretValue":{
+        "secretValue": {
             "value": "53cr3t"
         },
-        "keyName":{
+        "keyName": {
             "value": "prancer-key"
         },
-        "keyEnabled":{
-            "value": false
+        "keyEnabled": {
+            "value": true
         },
-        "keyExp":{
-            "value": -1
+        "keyExp": {
+            "value": 1697022048
         },
-        "keynbf":{
+        "keynbf": {
             "value": 300000
         },
-        "keyExpiryTime":{
+        "keyExpiryTime": {
             "value": ""
         },
-        "keySize":{
+        "keySize": {
             "value": 2048
         }
     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-KV-005 

 **Violation Description:** 

 This policy identifies Azure Key Vault secrets that do not have an expiratiSon date. As a best practice, set an expiration date for each secret and rotate the secret regularly. 

 **How to Fix:** 

 In Resource of type "Microsoft.KeyVault/vaults/secrets" make sure properties.attributes.exp exists and value isn't set empty.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.keyvault/vaults/secrets' target='_blank'>here</a> for details.