### PR TITLE
Fixed PR-AZR-ARM-NTW-002: Azure Network Watcher Network Security Group (NSG) traffic analytics should be enabled

### DIFF
--- a/networkwatcher/nw.azuredeploy.json
+++ b/networkwatcher/nw.azuredeploy.json
@@ -2,120 +2,119 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "location": {
-        "type": "string",
-        "defaultValue": "[resourceGroup().location]",
-        "metadata": {
-          "description": "Region where you resources are located"
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Region where you resources are located"
+            }
+        },
+        "NetworkWatcherName": {
+            "type": "string",
+            "defaultValue": "[concat('NetworkWatcher_', parameters('location'))]",
+            "metadata": {
+                "description": "Name of the Network Watcher attached to your subscription. Format: NetworkWatcher_<region_name>"
+            }
+        },
+        "FlowLogName": {
+            "type": "string",
+            "defaultValue": "FlowLog1",
+            "metadata": {
+                "description": "Chosen name of your Flow log resource"
+            }
+        },
+        "existingNSG": {
+            "type": "string",
+            "metadata": {
+                "description": "Resource ID of the target NSG"
+            }
+        },
+        "RetentionDays": {
+            "type": "int",
+            "defaultValue": 30,
+            "minValue": 0,
+            "maxValue": 365,
+            "metadata": {
+                "description": "Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365"
+            }
+        },
+        "FlowLogsversion": {
+            "type": "string",
+            "defaultValue": "2",
+            "allowedValues": [
+                "1",
+                "2"
+            ],
+            "metadata": {
+                "description": "FlowLogs Version. Correct values are 1 or 2 (default)"
+            }
+        },
+        "storageAccountType": {
+            "type": "string",
+            "defaultValue": "Standard_LRS",
+            "allowedValues": [
+                "Standard_LRS",
+                "Standard_GRS",
+                "Standard_ZRS"
+            ],
+            "metadata": {
+                "description": "Storage Account type"
+            }
         }
-      },
-      "NetworkWatcherName": {
-        "type": "string",
-        "defaultValue": "[concat('NetworkWatcher_', parameters('location'))]",
-        "metadata": {
-          "description": "Name of the Network Watcher attached to your subscription. Format: NetworkWatcher_<region_name>"
-        }
-      },
-      "FlowLogName": {
-        "type": "string",
-        "defaultValue": "FlowLog1",
-        "metadata": {
-          "description": "Chosen name of your Flow log resource"
-        }
-      },
-      "existingNSG": {
-        "type": "string",
-        "metadata": {
-          "description": "Resource ID of the target NSG"
-        }
-      },
-      "RetentionDays": {
-        "type": "int",
-        "defaultValue": 30,
-        "minValue": 0,
-        "maxValue": 365,
-        "metadata": {
-          "description": "Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365"
-        }
-      },
-      "FlowLogsversion": {
-        "type": "string",
-        "defaultValue": "2",
-        "allowedValues": [
-          "1",
-          "2"
-        ],
-        "metadata": {
-          "description": "FlowLogs Version. Correct values are 1 or 2 (default)"
-        }
-      },
-      "storageAccountType": {
-        "type": "string",
-        "defaultValue": "Standard_LRS",
-        "allowedValues": [
-          "Standard_LRS",
-          "Standard_GRS",
-          "Standard_ZRS"
-        ],
-        "metadata": {
-          "description": "Storage Account type"
-        }
-      }
     },
     "variables": {
-      "storageAccountName": "[concat('flowlogs', uniquestring(resourceGroup().id))]",    
-      "storageAccountResourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+        "storageAccountName": "[concat('flowlogs', uniquestring(resourceGroup().id))]",
+        "storageAccountResourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
     },
     "resources": [
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "apiVersion": "2019-06-01",
-        "name": "[variables('storageAccountName')]",
-        "location": "[parameters('location')]",
-        "sku": {
-          "name": "[parameters('storageAccountType')]"
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2019-06-01",
+            "name": "[variables('storageAccountName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[parameters('storageAccountType')]"
+            },
+            "kind": "StorageV2",
+            "properties": {}
         },
-        "kind": "StorageV2",
-        "properties": {
-        }
-      },
-      {
-        "type": "Microsoft.Network/networkWatchers/flowLogs",
-        "apiVersion": "2020-06-01",
-        "name": "[concat(parameters('NetworkWatcherName'), '/', parameters('FlowLogName'))]",
-        "location": "[parameters('location')]",
-        "properties": {
-          "targetResourceId": "[parameters('existingNSG')]",
-          "storageId": "[variables('storageAccountResourceId')]",
-          "enabled": false,
-          "flowAnalyticsConfiguration": {
-            "networkWatcherFlowAnalyticsConfiguration": {
-              "enabled": false,
-              "trafficAnalyticsInterval": 10,
-              "workspaceId": "",
-              "workspaceRegion": "",
-              "workspaceResourceId": ""
+        {
+            "type": "Microsoft.Network/networkWatchers/flowLogs",
+            "apiVersion": "2020-06-01",
+            "name": "[concat(parameters('NetworkWatcherName'), '/', parameters('FlowLogName'))]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "targetResourceId": "[parameters('existingNSG')]",
+                "storageId": "[variables('storageAccountResourceId')]",
+                "enabled": true,
+                "flowAnalyticsConfiguration": {
+                    "networkWatcherFlowAnalyticsConfiguration": {
+                        "enabled": true,
+                        "trafficAnalyticsInterval": 10,
+                        "workspaceId": "",
+                        "workspaceRegion": "",
+                        "workspaceResourceId": ""
+                    }
+                },
+                "retentionPolicy": {
+                    "days": "[parameters('RetentionDays')]",
+                    "enabled": true
+                },
+                "format": {
+                    "type": "JSON",
+                    "version": "[parameters('FlowLogsversion')]"
+                }
             }
-          },
-          "retentionPolicy": {
-            "days": "[parameters('RetentionDays')]",
-            "enabled": true
-          },
-          "format": {
-            "type": "JSON",
-            "version": "[parameters('FlowLogsversion')]"
-          }
         }
-      }
     ],
     "outputs": {
         "name": {
-          "type": "string",
-          "value": "[parameters('networkWatcherName')]"
+            "type": "string",
+            "value": "[parameters('networkWatcherName')]"
         },
         "id": {
-          "type": "string",
-          "value": "[resourceId('Microsoft.Network/networkWatchers', parameters('networkWatcherName'))]"
+            "type": "string",
+            "value": "[resourceId('Microsoft.Network/networkWatchers', parameters('networkWatcherName'))]"
         }
     }
-  }
+}


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NTW-002 

 **Violation Description:** 

 This policy identifies Azure Network Security Groups (NSG) for which flow logs are disabled. To perform this check, enable this action on the Azure Service Principal: 'Microsoft.Network/networkWatchers/queryFlowLogStatus/action'.<br><br>NSG flow logs, a feature of the Network Watcher app, enable you to view information about ingress and egress IP traffic through an NSG. The flow logs include information such as:<br>- Outbound and inbound flows on a per-rule basis.<br>- Network interface to which the flow applies.<br>- 5-tuple information about the flow (source/destination IP, source/destination port, protocol).<br>- Whether the traffic was allowed or denied.<br><br>As a best practice, enable NSG flow logs to improve network visibility. 

 **How to Fix:** 

 In Resource of type "Microsoft.network/networkwatchers/flowlogs" make sure properties.flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.enabled exists and value is set to true.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networkwatchers/flowlogs' target='_blank'>here</a> for details.