### PR TITLE
Fixed PR-AZR-ARM-NSG-014: Azure Network Security Group (NSG) should not allow SSH traffic from internet on port 22

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -24,8 +24,7 @@
               "sourcePortRanges": [],
               "destinationPortRanges": [
                 "20",
-                "21",
-                "22"
+                "21"
               ],
               "sourceAddressPrefixes": [],
               "destinationAddressPrefixes": [],
@@ -381,7 +380,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "TCP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 120,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -399,7 +398,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "UDP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 121,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +470,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-014 

 **Violation Description:** 

 Blocking SSH port 22 will protect users from attacks like Account compromise. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>