### PR TITLE
Fixed PR-AZR-ARM-NSG-022: Azure Network Security Group allows NetBIOS (UDP Port 137 and 138)

### DIFF
--- a/NSG/NSG.azuredeploy.parameters.json
+++ b/NSG/NSG.azuredeploy.parameters.json
@@ -181,7 +181,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "UDP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 109,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -399,7 +399,7 @@
             "properties": {
               "description": "allow inbound traffic",
               "protocol": "UDP",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 121,
               "direction": "Inbound",
               "sourcePortRange": "*",
@@ -471,7 +471,7 @@
             "properties": {
               "description": "allow inbound traffic on any protocol",
               "protocol": "*",
-              "access": "Allow",
+              "access": "Deny",
               "priority": 125,
               "direction": "Inbound",
               "sourcePortRange": "*",


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-NSG-022 

 **Violation Description:** 

 This policy detects any NSG rule that allows NetBIOS traffic on UDP port 137 and 138 from the internet. Review your list of NSG rules to ensure that your resources are not exposed._x005F<br>As a best practice, restrict NetBIOS solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for NSG by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networksecuritygroups' target='_blank'>here</a>