### PR TITLE
Fixed PR-AZR-ARM-ARC-001: Ensure that the Redis Cache accepts only SSL connections

### DIFF
--- a/redis-cache/azuredeploy.json
+++ b/redis-cache/azuredeploy.json
@@ -76,11 +76,12 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                  "name": "Premium",
-                  "family": "P",
-                  "capacity": 1
+                    "name": "Premium",
+                    "family": "P",
+                    "capacity": 1
                 },
-                "subnetId": "[variables('primarySubnetId')]"
+                "subnetId": "[variables('primarySubnetId')]",
+                "enableNonSslPort": false
             },
             "comments": "Create a Premium cache in the primary location in the primary virtual network."
         },


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-ARC-001 

 **Violation Description:** 

 It is recommended that Redis Cache should allow only SSL connections. Note: some Redis tools (like redis-cli) do not support SSL. When using such tools plain connection ports should be enabled. 

 **How to Fix:** 

 In Resource of type "Microsoft.Cache/redis" make sure properties.enableNonSslPort value is set to false or isn't exist .<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/Microsoft.Cache/redis' target='_blank'>here</a> for more details.