### PR TITLE
Fixed PR-AZR-ARM-ARC-002: Redis cache should have a backup

### DIFF
--- a/redis-cache/azuredeploy.json
+++ b/redis-cache/azuredeploy.json
@@ -76,9 +76,9 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                  "name": "Premium",
-                  "family": "P",
-                  "capacity": 1
+                    "name": "Premium",
+                    "family": "P",
+                    "capacity": 1
                 },
                 "subnetId": "[variables('primarySubnetId')]"
             },
@@ -112,7 +112,7 @@
             "properties": {
                 "linkedRedisCacheId": "[resourceId('Microsoft.Cache/Redis', parameters('newSecondaryCacheName'))]",
                 "linkedRedisCacheLocation": "[parameters('secondaryLocation')]",
-                "serverRole": "Primary"
+                "serverRole": "Secondary"
             }
         }
     ],


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-ARC-002 

 **Violation Description:** 

 Replicate Redis Cache server data to another Redis Cache server using geo replication. This feature is only available for Premium tier Redis Cache. From performance point of view, Microsoft recommends that both Redis Caches (Primary and the linked secondary) reside in the same region. 

 **How to Fix:** 

 In Resource of type "Microsoft.Cache/redis/linkedServers" make sure properties.serverRole value is set to Secondary.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.cache/redis/linkedservers' target='_blank'>here</a> for more details.