### PR TITLE
Fixed PR-AZR-ARM-SQL-032: Ensure Security Alert is enabled on Azure SQL Managed Instance

### DIFF
--- a/SQL/SQL-Instance/sqlinstance.azuredeploy.json
+++ b/SQL/SQL-Instance/sqlinstance.azuredeploy.json
@@ -90,7 +90,7 @@
                 "[resourceId('Microsoft.Sql/managedInstances', parameters('managedInstances_my_instance_name'))]"
             ],
             "properties": {
-                "state": "Disabled"
+                "state": "Enabled"
             }
         },
         {
@@ -113,10 +113,10 @@
             "apiVersion": "2021-02-01-preview",
             "name": "ActiveDirectory",
             "properties": {
-              "administratorType": "",
-              "login": "[parameters('administratorLogin')]",
-              "sid": "[parameters('administratorLoginPassword')]",
-              "tenantId": "[parameters('aadTenantId')]"
+                "administratorType": "",
+                "login": "[parameters('administratorLogin')]",
+                "sid": "[parameters('administratorLoginPassword')]",
+                "tenantId": "[parameters('aadTenantId')]"
             }
         }
     ]


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-SQL-032 

 **Violation Description:** 

 Advanced data security should be enabled on your SQL managed instance. 

 **How to Fix:** 

 In Resource of type "Microsoft.sql/managedinstances/securityalertpolicies" make sure properties.state exists and value is set to "Enabled" .<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/managedinstances/securityalertpolicies' target='_blank'>here</a>