### PR TITLE
Fixed PR-AZR-ARM-STR-003: Storage Accounts https based secure transfer should be enabled

### DIFF
--- a/ad-application-workloads/azuredeploy.json
+++ b/ad-application-workloads/azuredeploy.json
@@ -145,11 +145,11 @@
                 "description": "Load balancer name."
             }
         },
-        "omsWorkspaceName":{  
-            "type":"string",
-            "minLength":1,
-            "metadata":{  
-              "description":"Name of the OMS workspace used for diagnostic log integration."
+        "omsWorkspaceName": {
+            "type": "string",
+            "minLength": 1,
+            "metadata": {
+                "description": "Name of the OMS workspace used for diagnostic log integration."
             }
         }
     },
@@ -248,51 +248,52 @@
                 ]
             }
         },
-        {  
-            "type":"Microsoft.Storage/storageAccounts",
-            "name":"loadbanacerDiagonsticsettings",
-            "apiVersion":"2016-12-01",
-            "location":"[resourceGroup().location]",
-            "sku":{  
-              "name":"Standard_LRS"
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "loadbanacerDiagonsticsettings",
+            "apiVersion": "2016-12-01",
+            "location": "[resourceGroup().location]",
+            "sku": {
+                "name": "Standard_LRS"
             },
-            "kind":"Storage",
-            "tags":{  
-              "displayName":"Key Vault Diagnostic Storage Account')"
+            "kind": "Storage",
+            "tags": {
+                "displayName": "Key Vault Diagnostic Storage Account')"
             },
             "properties": {
-              "encryption": {
-                "keySource":"Microsoft.Storage",
-                "services": {
-                  "blob": {
-                    "enabled":true
-                  }
-                }
-              }
+                "encryption": {
+                    "keySource": "Microsoft.Storage",
+                    "services": {
+                        "blob": {
+                            "enabled": true
+                        }
+                    }
+                },
+                "supportsHttpsTrafficOnly": true
             }
         },
-        {  
-            "type":"microsoft.network/loadbalancers/providers/diagnosticsettings",
-            "name":"[concat(parameters('loadBalancerName'), '/Microsoft.Insights/service')]",
-            "apiVersion":"2016-09-01",
-            "location":"[resourceGroup().location]",
-            "dependsOn":[  
-              "[concat('Microsoft.Network/loadBalancers/', parameters('loadBalancerName'))]",
-              "[concat('Microsoft.Storage/storageAccounts/', 'loadbanacerDiagonsticsettings')]"
+        {
+            "type": "microsoft.network/loadbalancers/providers/diagnosticsettings",
+            "name": "[concat(parameters('loadBalancerName'), '/Microsoft.Insights/service')]",
+            "apiVersion": "2016-09-01",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/loadBalancers/', parameters('loadBalancerName'))]",
+                "[concat('Microsoft.Storage/storageAccounts/', 'loadbanacerDiagonsticsettings')]"
             ],
-            "properties":{  
-              "storageAccountId":"[resourceId('Microsoft.Storage/storageAccounts', 'loadbanacerDiagonsticsettings')]",
-              "workspaceId":"[resourceId('Microsoft.OperationalInsights/workspaces', parameters('omsWorkspaceName'))]",
-              "logs":[  
-                {  
-                  "category":"AuditEvent",
-                  "enabled":false,
-                  "retentionPolicy":{  
-                    "enabled":false,
-                    "days":30
-                  }
-                }
-              ]
+            "properties": {
+                "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', 'loadbanacerDiagonsticsettings')]",
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('omsWorkspaceName'))]",
+                "logs": [
+                    {
+                        "category": "AuditEvent",
+                        "enabled": false,
+                        "retentionPolicy": {
+                            "enabled": false,
+                            "days": 30
+                        }
+                    }
+                ]
             }
         },
         {


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-003 

 **Violation Description:** 

 The secure transfer option enhances the security of your storage account by only allowing requests to the storage account by a secure connection. For example, when calling REST APIs to access your storage accounts, you must connect using HTTPS. Any requests using HTTP will be rejected when 'secure transfer required' is enabled. When you are using the Azure files service, connection without encryption will fail, including scenarios using SMB 2.1, SMB 3.0 without encryption, and some flavors of the Linux SMB client. Because Azure storage doesn't support HTTPS for custom domain names, this option is not applied when using a custom domain name. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. supportsHttpsTrafficOnly should be true