### PR TITLE
Fixed PR-AZR-ARM-STR-003: Storage Accounts https based secure transfer should be enabled

### DIFF
--- a/storage/StorageA/blob.azuredeploy.parameters.json
+++ b/storage/StorageA/blob.azuredeploy.parameters.json
@@ -21,7 +21,7 @@
             "value": "TLS1_2"
         },
         "supportsHttpsTrafficOnly": {
-            "value": false
+            "value": true
         },
         "allowBlobPublicAccess": {
             "value": true
@@ -32,7 +32,7 @@
         "networkAclsDefaultAction": {
             "value": "Allow"
         },
-        "containerName":{
+        "containerName": {
             "value": "prancerstoragecontainer"
         }
     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-003 

 **Violation Description:** 

 The secure transfer option enhances the security of your storage account by only allowing requests to the storage account by a secure connection. For example, when calling REST APIs to access your storage accounts, you must connect using HTTPS. Any requests using HTTP will be rejected when 'secure transfer required' is enabled. When you are using the Azure files service, connection without encryption will fail, including scenarios using SMB 2.1, SMB 3.0 without encryption, and some flavors of the Linux SMB client. Because Azure storage doesn't support HTTPS for custom domain names, this option is not applied when using a custom domain name. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. supportsHttpsTrafficOnly should be true