### PR TITLE
Fixed PR-AZR-ARM-STR-004: Storage Accounts should have firewall rules enabled

### DIFF
--- a/storage/StorageA/blob.azuredeploy.json
+++ b/storage/StorageA/blob.azuredeploy.json
@@ -35,7 +35,7 @@
         "containerName": {
             "type": "string"
         },
-        "workspaceName" : {
+        "workspaceName": {
             "type": "string",
             "defaultValue": "GEN-UNIQUE"
         },
@@ -75,7 +75,7 @@
                     "keySource": "Microsoft.Storage"
                 }
             },
-            "resources":[
+            "resources": [
                 {
                     "type": "blobServices/containers",
                     "apiVersion": "2019-06-01",
@@ -129,36 +129,36 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
             "name": "[concat(parameters('storageAccountName'), '/blobServices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "apiVersion": "2017-05-01-preview",
             "properties": {
-              "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
-              "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
-              "logs": [
-                  {
-                      "category": "StorageRead",
-                      "enabled": false
-                  },
-                  {
-                      "category": "StorageWrite",
-                      "enabled": true
-                  },
-                  {
-                      "category": "StorageDelete",
-                      "enabled": true
-                  }
-              ],
-              "metrics": [
-                  {
-                      "category": "Transaction",
-                      "enabled": true
-                  }
-              ]
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
+                "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
+                "logs": [
+                    {
+                        "category": "StorageRead",
+                        "enabled": false
+                    },
+                    {
+                        "category": "StorageWrite",
+                        "enabled": true
+                    },
+                    {
+                        "category": "StorageDelete",
+                        "enabled": true
+                    }
+                ],
+                "metrics": [
+                    {
+                        "category": "Transaction",
+                        "enabled": true
+                    }
+                ]
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/queueservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {
@@ -187,7 +187,7 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/tableservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {

--- a/storage/StorageA/blob.azuredeploy.parameters.json
+++ b/storage/StorageA/blob.azuredeploy.parameters.json
@@ -30,9 +30,9 @@
             "value": "None"
         },
         "networkAclsDefaultAction": {
-            "value": "Allow"
+            "value": "Deny"
         },
-        "containerName":{
+        "containerName": {
             "value": "prancerstoragecontainer"
         }
     }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-004 

 **Violation Description:** 

 Turning on firewall rules for your storage account blocks incoming requests for data by default, unless the requests come from a service that is operating within an Azure Virtual Network (VNet). Requests that are blocked include those from other Azure services, from the Azure portal, from logging and metrics services, and so on.<br><br>You can grant access to Azure services that operate from within a VNet by allowing the subnet of the service instance. Enable a limited number of scenarios through the Exceptions mechanism described in the following section. To access the Azure portal, you would need to be on a machine within the trusted boundary (either IP or VNet) that you set up. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. networkAcls should be configured