### PR TITLE
Fixed PR-AZR-ARM-STR-004: Storage Accounts should have firewall rules enabled

### DIFF
--- a/storage/StorageB/deploy.json
+++ b/storage/StorageB/deploy.json
@@ -71,16 +71,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-                        {
-                            "id": "[variables('containerSubnetRef')]",
-                            "action": "Allow"
-                        },
-                        {
-                            "id": "[variables('storageSubnetRef')]",
-                            "action": "Allow"
-                        }
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Deny"
                 },
                 "supportsHttpsTrafficOnly": false,
@@ -182,7 +173,8 @@
                 },
                 "accessTier": "Cool"
             }
-        },{
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[parameters('storageAccountName3')]",
@@ -195,9 +187,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-  
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Allow"
                 },
                 "supportsHttpsTrafficOnly": false,


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-004 

 **Violation Description:** 

 Turning on firewall rules for your storage account blocks incoming requests for data by default, unless the requests come from a service that is operating within an Azure Virtual Network (VNet). Requests that are blocked include those from other Azure services, from the Azure portal, from logging and metrics services, and so on.<br><br>You can grant access to Azure services that operate from within a VNet by allowing the subnet of the service instance. Enable a limited number of scenarios through the Exceptions mechanism described in the following section. To access the Azure portal, you would need to be on a machine within the trusted boundary (either IP or VNet) that you set up. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. networkAcls should be configured