### PR TITLE
Fixed PR-AZR-ARM-STR-004: Storage Accounts should have firewall rules enabled

### DIFF
--- a/storage/StorageC/storage.azuredeploy.json
+++ b/storage/StorageC/storage.azuredeploy.json
@@ -6,31 +6,31 @@
             "type": "string",
             "metadata": {
                 "description": "Location of the storagr account"
-              }
+            }
         },
         "storageAccountName": {
             "type": "string",
             "metadata": {
                 "description": "Name of the storage account"
-              }
+            }
         },
         "accountType": {
             "type": "string",
             "metadata": {
                 "description": "Type of account i.e Standard/Premium LRS/GRS"
-              }
+            }
         },
         "kind": {
             "type": "string",
             "metadata": {
                 "description": "Kind of storag account required for teh storage account"
-              }
+            }
         },
         "accessTier": {
             "type": "string",
             "metadata": {
                 "description": "Access Tier of the storage account default Hot, will chnage it to the Cold "
-              }
+            }
         },
         "minimumTlsVersion": {
             "type": "string"
@@ -42,7 +42,7 @@
             "type": "bool",
             "metadata": {
                 "description": "Allow Blob public access to Blob storage"
-              }
+            }
         },
         "networkAclsBypass": {
             "type": "string"

--- a/storage/StorageC/storage.azuredeploy.parameters.json
+++ b/storage/StorageC/storage.azuredeploy.parameters.json
@@ -30,7 +30,7 @@
             "value": "None"
         },
         "networkAclsDefaultAction": {
-            "value": "Allow"
+            "value": "Deny"
         }
     }
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-004 

 **Violation Description:** 

 Turning on firewall rules for your storage account blocks incoming requests for data by default, unless the requests come from a service that is operating within an Azure Virtual Network (VNet). Requests that are blocked include those from other Azure services, from the Azure portal, from logging and metrics services, and so on.<br><br>You can grant access to Azure services that operate from within a VNet by allowing the subnet of the service instance. Enable a limited number of scenarios through the Exceptions mechanism described in the following section. To access the Azure portal, you would need to be on a machine within the trusted boundary (either IP or VNet) that you set up. 

 **How to Fix:** 

 Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. networkAcls should be configured