### PR TITLE
Fixed PR-AZR-ARM-STR-008: Ensure critical data storage in Storage Account is encrypted with Customer Managed Key

### DIFF
--- a/storage/StorageB/deploy.json
+++ b/storage/StorageB/deploy.json
@@ -95,7 +95,7 @@
                             "enabled": false
                         }
                     },
-                    "keySource": "Microsoft.Storage"
+                    "keySource": "Microsoft.Keyvault"
                 },
                 "accessTier": "Cool"
             }
@@ -182,7 +182,8 @@
                 },
                 "accessTier": "Cool"
             }
-        },{
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[parameters('storageAccountName3')]",
@@ -195,9 +196,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-  
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Allow"
                 },
                 "supportsHttpsTrafficOnly": false,


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-008 

 **Violation Description:** 

 By default, data in the storage account is encrypted using Microsoft Managed Keys at rest. All Azure Storage resources are encrypted, including blobs, disks, files, queues, and tables. All object metadata is also encrypted. However, if you want to control and manage this encryption key yourself, you can specify a customer-managed key, that key is used to protect and control access to the key that encrypts your data. You can also choose to automatically update the key version used for Azure Storage encryption whenever a new version is available in the associated Key Vault. 

 **How to Fix:** 

 In Resource of type "Microsoft.storage/storageaccounts" make sure properties.encryption.keySource exists and value is set to "Microsoft.Keyvault".<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a> for details.