### PR TITLE
Fixed PR-AZR-ARM-STR-009: Storage Accounts location configuration should be inside of Europe

### DIFF
--- a/storage/StorageC/storage.azuredeploy.parameters.json
+++ b/storage/StorageC/storage.azuredeploy.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "location": {
-            "value": "eastus"
+            "value": "northeurope"
         },
         "storageAccountName": {
             "value": "prancerstorageaccount007"


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-009 

 **Violation Description:** 

 Identify Storage Accounts outside of the following regions: northeurope, westeurope 

 **How to Fix:** 

 In Resource of type "Microsoft.storage/storageaccounts" make sure location is set to northeurope or westeurope.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a> for details.