### PR TITLE
Fixed PR-AZR-ARM-STR-009: Storage Accounts location configuration should be inside of Europe

### DIFF
--- a/storage/StorageB/deploy.json
+++ b/storage/StorageB/deploy.json
@@ -47,7 +47,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "[resourceGroup().location]",
+            "defaultValue": "northeurope",
             "metadata": {
                 "description": "Location for all resources."
             }
@@ -182,7 +182,8 @@
                 },
                 "accessTier": "Cool"
             }
-        },{
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[parameters('storageAccountName3')]",
@@ -195,9 +196,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-  
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Allow"
                 },
                 "supportsHttpsTrafficOnly": false,


### PR DESCRIPTION
**Violation Id:** PR-AZR-ARM-STR-009 

 **Violation Description:** 

 Identify Storage Accounts outside of the following regions: northeurope, westeurope 

 **How to Fix:** 

 In Resource of type "Microsoft.storage/storageaccounts" make sure location is set to northeurope or westeurope.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a> for details.